### PR TITLE
fixed typo in split->str2octs arguments list

### DIFF
--- a/scripts/snmpsimd.py
+++ b/scripts/snmpsimd.py
@@ -267,7 +267,7 @@ class DataFile(AbstractLayout):
                 offset = searchRecordByOid(oid, text, self.__textParser)
                 subtreeFlag = exactMatch = False
             else:
-                offset, subtreeFlag, prevOffset = line.split(str2octs(',', 2))
+                offset, subtreeFlag, prevOffset = line.split(str2octs(','), 2)
                 subtreeFlag, exactMatch = int(subtreeFlag), True
 
             offset = int(offset)


### PR DESCRIPTION
str2octs is lambda function with 1 argument, closing parenthesis was in wrong place