### PR TITLE
pass proper isolation level string to database in SQL variation module

### DIFF
--- a/variation/sql.py
+++ b/variation/sql.py
@@ -88,7 +88,7 @@ def variate(oid, tag, value, **context):
 
     try:
         cursor.execute(
-            'set session transaction isolation level %s' % moduleContext['isolationLevel']
+            'set session transaction isolation level %s' % isolationLevels[moduleContext['isolationLevel']]
         )
         cursor.fetchall()
     except:  # non-MySQL/Postgres


### PR DESCRIPTION
In the current version of the SQL variation module, the numeric isoletion level ID is directly passed to the SQL query which does not work, at least for PostgreSQL. Looks like the intention was to translate it to the corresponding string.