### PR TITLE
make index file check work for dbm.dumb

### DIFF
--- a/snmpsim/record/search/database.py
+++ b/snmpsim/record/search/database.py
@@ -60,13 +60,14 @@ class RecordIndex:
 
         for dbFile in (
             self.__dbFile + os.path.extsep + 'db',
+            self.__dbFile + os.path.extsep + 'dat',
             self.__dbFile
             ):
             if os.path.exists(dbFile):
                 if textFileTime < os.stat(dbFile)[8]:
                     if indexNeeded:
                         log.msg('Forced index rebuild %s' % dbFile)
-                    elif not whichdb(dbFile):
+                    elif not whichdb(self.__dbFile):
                         indexNeeded = True
                         log.msg('Unsupported index format, rebuilding index %s' % dbFile)
                 else:


### PR DESCRIPTION
Another thing that I noticed is that in my current setup (Python 3.6, Windows), snmpsim repeatedly claims that there is no index available and needs to rebuild (which is really slow for larger files). After some digging, I found that the dbm.dumb that is being used by anydbm here does not create .dbm files (anymore?), but just .dbm.dat and .dbm.dir. This breaks the existing index detection.
I therefore added a check for .dbm.dat. Further, the whichdb() call should always use self.__dbFile because that's the file name that will also be used later when actually using the database.