### PR TITLE
Add SNMP Context Name support

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,11 @@ Revision 0.4.8, released XX-08-2019
 -----------------------------------
 
 - Code base PEP8'ed
+- Added support for SNMP Context Engine ID mapping to the file system paths.
+  This feature allows for every single SNMP engine to simulate multiple
+  SNMP contexts based on different .snmprec files. On top of that, this
+  feature simplifies the mapping of empty SNMP community and context names
+  to .snmprec files.
 - Added support for simulation based on compressed .snmprec files using
   bzip2 compression algorithm (.snmprec.bz2), as well as recording straight
   into this compressed format.

--- a/snmpsim/record/search/database.py
+++ b/snmpsim/record/search/database.py
@@ -6,7 +6,6 @@
 #
 import os
 import sys
-import bz2
 
 if sys.version_info[0] < 3:
     import anydbm as dbm


### PR DESCRIPTION
Added support for SNMP Context Engine ID mapping to the file
system paths. This feature allows for every single SNMP engine
to simulate multiple SNMP contexts based on different .snmprec
files.

On top of that, this feature simplifies the mapping of empty SNMP
community and context names to .snmprec files.