### PR TITLE
Fix incorrect permissions of cache index files when started as root a…

### DIFF
--- a/scripts/snmpsimd.py
+++ b/scripts/snmpsimd.py
@@ -1599,12 +1599,13 @@ else:  # v3 mode
 
                     dataIndexInstrumController = DataIndexInstrumController()
 
-                    configureManagedObjects(
-                        ctxDataDirs or dataDirs or confdir.data, 
-                        dataIndexInstrumController,
-                        snmpEngine,
-                        snmpContext
-                    )
+                    with daemon.PrivilegesOf(procUser, procGroup):
+                        configureManagedObjects(
+                            ctxDataDirs or dataDirs or confdir.data,
+                            dataIndexInstrumController,
+                            snmpEngine,
+                            snmpContext
+                        )
 
                 # Configure access to data index
 


### PR DESCRIPTION
…nd changing to --process-user

This appears to fix the issue with creating index files with the incorrect permissions and addressing Issue #84 