### PR TITLE
Add REST API spec on snmpsimd management

### DIFF
--- a/docs/snmpsim-mgmt-api.yaml
+++ b/docs/snmpsim-mgmt-api.yaml
@@ -1,0 +1,1170 @@
+openapi: 3.0.0
+info:
+  license:
+    name: BSD License
+  version: '1.0.0'
+  title: 'SNMP Simulator Control Plane REST API'
+  description: >
+    The Management API is designed to support complete SNMP Simulator work flow
+    remotely. As such, Management API supports SNMp entity (Agent) creation,
+    configuration and eventual tear down. Simulation data can be uploaded,
+    modified, removed and exposed under different circumstances. On top of
+    that, SNMP agents can be grouped together to form "virtual labs" that
+    can be brought up/down altogether.
+
+    Typical management work flow looks like this:
+
+    1. Create SNMP Agent using `/entities` REST API endpoint. You can supply
+       complete agent configuration at once or add/modify it incrementally.
+       Important configuration items include: SNMP Engine ID, SNMPv3 VACM
+       user(s) credentials, SNMPv1/v2c community name(s)
+    2. Create SNMP transport endpoint(s) using `/endpoints`. These are the
+       address(es) where SNMP agent is listening for inbound SNMP commands.
+       When creating an endpoint, bind it to one specific SNMP entity.
+    3. Create SNMP simulation data by uploading the entire `.snmprec` file
+       via `/objects` endpoint. You can read/modify it on per-line basis
+       later on.
+    4. Expose simulation data to SNMP agent(s) by creating one or more request
+       routing rules via `/selectors` endpoint. Each of the selectors will
+       be examined in specified order at the time of SNMP command processing.
+       First selector matching request properties will be picked and
+       associated simulation data will be used for answering the query.
+    5. Optionally, add your new SNMP entity to a new or existing group via
+       `/groups` endpoint.
+
+servers:
+  - url: https://virtserver.swaggerhub.com/etingof/snmpsimd-control-plane/1.0.0
+
+paths:
+  /endpoints:
+    get:
+      description: >
+        This resource represents a list of all existing transport endpoints
+        that can be used by SNMP entities.
+      summary: >
+        List all existing transport endpoints
+      operationId: listEndpoints
+      tags:
+        - endpoints
+      responses:
+        "200":
+          description: >
+            An array of transport endpoints
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Endpoints"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a new SNMP transport endpoint
+      operationId: createEndpoint
+      tags:
+        - endpoints
+      requestBody:
+        description: >
+          Receive a new endpoint object bound to an existing SNMP entity.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Endpoint'
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /endpoints/{endpointId}:
+    description: >
+      This resource represents a single SNMP transport endpoint identified
+      by `endpointId`.
+    get:
+      summary: Info for a specific SNMP transport endpoint
+      operationId: showEndpointById
+      tags:
+        - endpoints
+      parameters:
+        - name: endpointId
+          in: path
+          required: true
+          description: The id of the endpoint to retrieve
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Endpoint"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      summary: Delete SNMP transport endpoint
+      operationId: deleteEndpoint
+      tags:
+        - endpoints
+      parameters:
+        - name: endpointId
+          in: path
+          required: true
+          description: The id of the endpoint to retrieve
+          schema:
+            type: integer
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /selectors:
+    description: >
+      This resource represents a list of all existing simulation data
+      selectors.
+    get:
+      summary: >
+        List all existing simulation data selectors
+      operationId: listSelectors
+      tags:
+        - selectors
+      responses:
+        "200":
+          description: >
+            An array of simulation data selectors
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Selectors"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a new simulation data selector
+      operationId: createSelector
+      tags:
+        - selectors
+      requestBody:
+        description: >
+          Receive a new selector object referring to an existing simulation
+          data object.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Selector'
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /selectors/{selectorId}:
+    description: >
+      This resource represents a single simulation data selector identified
+      by `selectorId`.
+    get:
+      summary: Info for a specific simulation data selectors
+      operationId: showSelectorById
+      tags:
+        - selectors
+      parameters:
+        - name: selectorId
+          in: path
+          required: true
+          description: The id of the selector to retrieve
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Selector"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      summary: Delete simulation data selector
+      operationId: deleteSelector
+      tags:
+        - selectors
+      parameters:
+        - name: selectorId
+          in: path
+          required: true
+          description: The id of the selector to retrieve
+          schema:
+            type: integer
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /objects:
+    description: >
+      This resource represents a collection of simulated data objects. Each
+      `object` in the collection corresponds to a single `.snmprec` file.
+    get:
+      summary: >
+        List all existing simulation data objects.
+      operationId: listObjects
+      tags:
+        - objects
+      responses:
+        "200":
+          description: >
+            An array of simulation data objects
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Objects"
+            text/plain:
+              schema:
+                type: string
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a new simulation data objects
+      operationId: createObject
+      tags:
+        - objects
+      requestBody:
+        description: >
+          Receive the entire .snmprec file in a JSON object or ASCII text form.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Object'
+          text/plain:
+            schema:
+              type: string
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /objects/{objectId}:
+    description: >
+      This resource represents a single simulation data object identified
+      by `objectId`.
+    get:
+      summary: Info for a specific simulation data object
+      operationId: showObjectsById
+      tags:
+        - objects
+      parameters:
+        - name: objectId
+          in: path
+          required: true
+          description: The id of the object to retrieve
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Object"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      summary: Delete simulation data object
+      operationId: deleteObject
+      tags:
+        - objects
+      parameters:
+        - name: objectId
+          in: path
+          required: true
+          description: The id of the object to retrieve
+          schema:
+            type: integer
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /entities:
+    description: >
+      This resource represents a list of all SNMP entities (agents).
+    get:
+      summary: >
+        List all existing SNMP entities
+      operationId: listEntities
+      tags:
+        - entities
+      responses:
+        "200":
+          description: >
+            An array of SNMP entities
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Entities"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create new SNMP entity
+      operationId: createEntity
+      tags:
+        - entities
+      requestBody:
+        description: >
+          New SNMP entity
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Entity'
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /entities/{entityId}:
+    description: >
+      This resource represents a single SNMP entity (agent) identified
+      by `entityId`.
+    get:
+      summary: Info for a specific SNMP entity
+      operationId: showEntityById
+      tags:
+        - entities
+      parameters:
+        - name: entityId
+          in: path
+          required: true
+          description: The id of the entity to retrieve
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Entity"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      summary: Delete SNMP entity
+      operationId: deleteEntity
+      tags:
+        - entities
+      parameters:
+        - name: entityId
+          in: path
+          required: true
+          description: The id of the entity to retrieve
+          schema:
+            type: integer
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /entities/{entityId}/users:
+    description: >
+      This resource represents a SNMPv3 USM user record associated with SNMP
+      entity identified by `entityId`.
+    put:
+      summary: Add new USM user entry
+      operationId: addUsmUser
+      tags:
+        - entities
+      parameters:
+        - name: entityId
+          in: path
+          required: true
+          description: The id of the entity
+          schema:
+            type: integer
+      requestBody:
+        description: >
+          Receive a new USM user entry
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+      responses:
+        "204":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /entities/{entityId}/users/{userId}:
+    description: >
+      This resource represents a SNMPv3 USM user record associated with SNMP
+      entity identified by `entityId`.
+    delete:
+      summary: Remove USM user entry
+      operationId: delUsmUser
+      tags:
+        - entities
+      parameters:
+        - name: entityId
+          in: path
+          required: true
+          description: The id of the entity
+          schema:
+            type: integer
+        - name: userId
+          in: path
+          required: true
+          description: The id of the USM entry
+          schema:
+            type: integer
+      responses:
+        "204":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /entities/{entityId}/communities:
+    description: >
+      This resource represents a SNMP community name record associated with
+      SNMP entity identified by `entityId`.
+    put:
+      summary: Add new SNMPv1/v2c community name
+      operationId: addCommunity
+      tags:
+        - entities
+      parameters:
+        - name: entityId
+          in: path
+          required: true
+          description: The id of the entity
+          schema:
+            type: integer
+      requestBody:
+        description: >
+          Receive a new SNMPv1/v/2c community name entry
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Community'
+      responses:
+        "204":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /entities/{entityId}/communities/{communityId}:
+    description: >
+      This resource represents a SNMP community name record associated with
+      SNMP entity identified by `entityId`.
+    delete:
+      summary: Delete new SNMPv1/v2c community name
+      operationId: delCommunity
+      tags:
+        - entities
+      parameters:
+        - name: entityId
+          in: path
+          required: true
+          description: The id of the entity
+          schema:
+            type: integer
+        - name: communityId
+          in: path
+          required: true
+          description: The id of the community entry
+          schema:
+            type: integer
+      responses:
+        "204":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /entities/{entityId}/access:
+    description: >
+      This resource represents a SNMPv3 access entry (VACM) associated with
+      SNMP entity identified by `entityId`.
+    put:
+      summary: Add new SNMPv3 VACM entry
+      operationId: addVacm
+      tags:
+        - entities
+      parameters:
+        - name: entityId
+          in: path
+          required: true
+          description: The id of the entity
+          schema:
+            type: integer
+      requestBody:
+        description: >
+          Receive a new SNMPv3 VACM entry
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Access'
+      responses:
+        "204":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /entities/{entityId}/access/{accessId}:
+    description: >
+      This resource represents a SNMPv3 access entry (VACM) associated with
+      SNMP entity identified by `entityId`.
+    delete:
+      summary: Add new SNMPv3 VACM entry
+      operationId: delVacm
+      tags:
+        - entities
+      parameters:
+        - name: entityId
+          in: path
+          required: true
+          description: The id of the entity
+          schema:
+            type: integer
+        - name: accessId
+          in: path
+          required: true
+          description: The id of the VACM access entry
+          schema:
+            type: integer
+      responses:
+        "204":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /groups:
+    get:
+      description: >
+        This resource represents a list of all existing SNMP entity groups.
+      summary: >
+        List all existing SNMP entity groups
+      operationId: listGroups
+      tags:
+        - groups
+      responses:
+        "200":
+          description: >
+            An array of SNMP entity groups
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Groups"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create new SNMP entity group
+      operationId: createGroup
+      tags:
+        - groups
+      requestBody:
+        description: >
+          New group optionally containing SNMP entity IDs.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Group'
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /groups/{groupId}:
+    description: >
+      This resource represents a SNMP entity group identified by `groupId`.
+    get:
+      summary: Info for a specific SNMP transport endpoint
+      operationId: showGroupById
+      tags:
+        - groups
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          description: The id of the SNMP entity group
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Group"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      summary: Delete SNMP entity grouping
+      operationId: deleteGroup
+      tags:
+        - groups
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          description: The id of the SNMP entity group
+          schema:
+            type: integer
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /groups/{groupId}/entity/{entityId}:
+    description: >
+      This resource represents a SNMP entity identified by `entityId`
+      associated with group identified by `groupId`.
+    put:
+      summary: Add existing SNMP entity to group
+      operationId: addToGroup
+      tags:
+        - groups
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          description: The id of the SNMP entity group
+          schema:
+            type: integer
+        - name: entityId
+          in: path
+          required: true
+          description: The id of the SNMP entity
+          schema:
+            type: integer
+      responses:
+        "204":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      summary: Remove SNMP entity from group
+      operationId: delFromGroup
+      tags:
+        - groups
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          description: The id of the SNMP entity group
+          schema:
+            type: integer
+        - name: entityId
+          in: path
+          required: true
+          description: The id of the SNMP entity
+          schema:
+            type: integer
+      responses:
+        "204":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /groups/{groupId}/power:
+    description: >
+      This resource represents group power state. The group is identified by
+      `groupId`, power state can be queried and modified.
+    put:
+      summary: Change group power state
+      operationId: setGroupPowerState
+      tags:
+        - groups
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          description: The id of the SNMP entity group
+          schema:
+            type: integer
+      requestBody:
+        description: >
+          Carries desired group power state
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupPowerState'
+      responses:
+        "204":
+          description: Null response
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+components:
+  schemas:
+    Access:
+      description: >
+        SNMP managed objects are identified by OIDs. SNMP includes the accesss
+        control subsystem (known as VACM) that can "mask" some of the OIDs, in
+        the imaginary tree of sub-OID numbers, on per-user/protocol version
+        basis.
+      type: object
+      required:
+        - id
+        - subtree
+      properties:
+        id:
+          description: >
+            Access entry ID
+          type: integer
+          format: int64
+        subtree:
+          description: >
+            OID subtree that this entry applies access control on.
+          type: string
+          pattern: ".*"  # TODO OID regexp
+        mask:
+          description: >
+            An OID consisting of 1's and 0's to define branches of OID tree this
+            entry applies access control on. Technically, logical *AND* operation
+            is applied on `subree` and `mask` yielding access-significant sub-OIDs.
+          type: string
+          pattern: ".*"  # TODO OID regexp
+        protocol:
+          description: >
+            SNMP protocol version this entry is applicable to
+          type: string
+          enum: [v1, v2c, v3]
+        security:
+          description: >
+            SNMP security level this entry is applicable to
+          type: string
+          enum: [noAuthNoPriv, authNoPriv, authPriv]
+        mode:
+          description: >
+            SNMP operation this entry is applicable to
+          type: string
+          enum: [read, write, notify]
+        context:
+          description: >
+            SNMP context name this entry is applicable to.
+          type: string
+        partial:
+          description: >
+            If true, match `context` as SNMP context name prefix rather than
+            matching exactly.
+          type: boolean
+
+    User:
+      description: >
+        SNMPv3 USM user entry. Contains SNMPv3 credentials grouped by
+        user name.
+      required:
+        - id
+        - username
+      properties:
+        id:
+          description: >
+            User entry ID
+          type: integer
+          format: int64
+        username:
+          description: >
+            USM user name
+          type: string
+          minLength: 1
+          maxLength: 32
+        v3AuthKey:
+          description: >
+            USM user authentication key
+          type: string
+          minLength: 8
+          maxLength: 32
+        v3AuthProtocol:
+          description: >
+            User authentication protocol
+          type: string
+          enum: [md5, sha, sha224, sha256, sha384, sha512, none]
+        v3PrivKey:
+          description: >
+            USM user privacy (encryption) key
+          type: string
+          minLength: 8
+          maxLength: 32
+        v3PrivProtocol:
+          type: string
+          enum: [des, 3des, aes, aes128, aes192, aes192blmt, aes256,
+                 aes256blmt, none]
+
+    Community:
+      description: >
+        SNMPv1/v2c community name. Only applicable to legacy SNMPv1/v2c
+        operations.
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          description: >
+            Community name ID
+          type: integer
+          format: int64
+        name:
+          type: string
+
+    Engine:
+      description: >
+        Represents a unique, independent and fully operational SNMP engine, though
+        not yet attached to any transport endpoints.
+      type: object
+      required:
+        - engineId
+      properties:
+        engineId:
+          type: string
+          pattern: ".*"  # TODO: three distinct formats
+        users:
+          type: array
+          items:
+            $ref: "#/components/schemas/User"
+        communities:
+          type: array
+          items:
+            $ref: "#/components/schemas/Community"
+        access:
+          type: array
+          items:
+            $ref: "#/components/schemas/Access"
+
+    Endpoint:
+      description: >
+        SNMP transport endpoint. Each SNMP engine can bind one or more
+        transport endpoints. Each transport endpoint can only be bound
+        by one SNMP engine.
+      type: object
+      required:
+        - id
+        - domain
+        - address
+      properties:
+        id:
+          description: >
+            Transport endpoint unique ID
+          type: integer
+          format: int64
+        entityId:
+          description: >
+            SNMP entity ID binding this endpoint
+          type: integer
+          format: int64
+        domain:
+          type: string
+          enum: [udpv4, udpv6]
+        address:
+          type: string
+          pattern: ".*"  # IPv4:port, IPv6:port, FQDN(?)
+
+    Endpoints:
+      description: >
+        Collection of SNMP transport endpoints.
+      type: array
+      items:
+        $ref: "#/components/schemas/Endpoint"
+
+    Object:
+      description: >
+        SNMP managed object instance. On SNMP side of things, managed object
+        instance is identified by a unique OID and, sometimes, an associated
+        value representing the state of the backend application object being
+        managed via SNMP.
+
+        Depending on the nature of the managed object, associated value can
+        be settable and/or modifiable.
+      type: object
+      required:
+        - id
+        - oid
+        - type
+      properties:
+        id:
+          type: integer
+          format: int64
+        oid:
+          description: >
+            OID associated with this managed object instance
+          type: string
+          pattern: ".*"  # TODO OID regexp
+        type:
+          description: >
+            SNMP type of the value assocated with this managed object.
+          type: string
+          enum: [integer32, octetstring, counter32, counter64, gauge32,
+                 opaque, ipaddress, null, timeticks]
+        value:
+          description: >
+            Static value returned by this managed object
+          type: string
+        variation:
+          description: >
+            Variation module invoked when serving this managed object
+          type: string
+          enum: [numeric, error, delay, notification, multiplex, redis,
+                 sql, subprocess, writecache]
+        variationOptions:
+          type: string
+
+    Objects:
+      description: >
+        Ordered collection of SNMP managed objects
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        objects:
+          type: array
+          items:
+            $ref: "#/components/schemas/Object"
+
+    Selector:
+      description: >
+        Set of rules for SNMP entity to choose SNMP managed objects collection
+        associated with this selector. All of the fields in the selector must
+        match for this selector to be chosen.
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+          format: int64
+        contextEngineIds:
+          description: >
+            This context is applicable for queries for this SNMP context engine ID.
+            Empty value matches SNMP engine ID of SNMP engine considering this
+            selector.
+          type: array
+          items:
+            type: string
+        contextNames:
+          description: >
+            This context is applicable for queries for this SNMP context name.
+          type: array
+          items:
+            type: string
+        endpoints:
+          description: >
+            This context is applicable for queries coming via these endpoints.
+            Empty value matches any endpoint.
+          type: array
+          items:
+            type: integer
+            format: int64
+        source:
+          description: >
+            This context is applicable for queries coming from these network addresses.
+            Empty value matches any source.
+          type: array
+          items:
+            type: string
+        objects:
+          description: >
+            ID of SNMP managed objects collection associated with this selector.
+          type: integer
+          format: int64
+
+    Selectors:
+      description: >
+        Ordered list of selector IDs for SNMP entity to consider. First match
+        satisfies the query.
+      type: array
+      items:
+        $ref: "#/components/schemas/Selector"
+
+    Entity:
+      description: >
+        SNMP entity or SNMP agent. Consists of SNMP engine and transport
+        endpoints it binds.
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        engine:
+          $ref: "#/components/schemas/Engine"
+
+    Entities:
+      type: array
+      items:
+        $ref: "#/components/schemas/Entity"
+
+    Group:
+      description: >
+        Group of SNMP entities. Some operations can be applied to them all
+        at once.
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        entities:
+          description: >
+            SNMP entities IDs belonging to this group
+          type: array
+          items:
+            type: integer
+            format: int64
+        state:
+          description: >
+            State of SNMP entities in this group
+          type: string
+          enum: [up, down]
+
+    Groups:
+      description: >
+        A collection of groups of SNMP entities.
+      type: array
+      items:
+        $ref: "#/components/schemas/Group"
+
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+
+    GroupPowerState:
+      description: >
+        Desired group power state.
+      type: object
+      properties:
+        state:
+          description: >
+            Power state of all SNMP entities in this group
+          type: string
+          enum: [up, down]

--- a/docs/snmpsim-mgmt-api.yaml
+++ b/docs/snmpsim-mgmt-api.yaml
@@ -12,23 +12,29 @@ info:
     that, SNMP agents can be grouped together to form "virtual lab" that
     can be brought up/down altogether.
 
+
     Typical management work flow looks like this:
+
 
     1. Create SNMP Agent using `/agents` REST API endpoint. You can supply
        complete agent configuration at once or add/modify it incrementally.
        Important configuration items include: SNMP Engine ID, SNMPv3 VACM
        user(s) credentials, SNMPv1/v2c community name(s)
+
     2. Create SNMP transport endpoint(s) using `/endpoints`. These are the
        address(es) where SNMP agent is listening for inbound SNMP commands.
        When creating an endpoint, bind it to one specific SNMP agent.
+
     3. Create SNMP simulation data by uploading the entire `.snmprec` file
        via `/objects` endpoint. You can read/modify it on per-line basis
        later on.
+
     4. Expose simulation data to SNMP agent(s) by creating one or more request
        routing rules via `/selectors` endpoint. Each of the selectors will
        be examined in specified order at the time of SNMP command processing.
        First selector matching request properties will be picked and
        associated simulation data will be used for answering the query.
+
     5. Optionally, add your new SNMP agent to a new or existing lab via
        `/labs` endpoint.
 

--- a/docs/snmpsim-mgmt-api.yaml
+++ b/docs/snmpsim-mgmt-api.yaml
@@ -5,7 +5,7 @@ info:
   version: '1.0.0'
   title: 'SNMP Simulator Control Plane REST API'
   description: >
-    The Management API is designed to support complete SNMP Simulator work flow
+    Management API is designed to support complete SNMP Simulator work flow
     remotely. As such, Management API supports SNMP Agent creation,
     configuration and eventual tear down. Simulation data can be uploaded,
     modified, removed and exposed under different circumstances. On top of
@@ -96,7 +96,7 @@ paths:
         - name: endpointId
           in: path
           required: true
-          description: The id of the endpoint to retrieve
+          description: The ID of the endpoint to retrieve
           schema:
             type: integer
       responses:
@@ -121,7 +121,7 @@ paths:
         - name: endpointId
           in: path
           required: true
-          description: The id of the endpoint to retrieve
+          description: The ID of the endpoint to retrieve
           schema:
             type: integer
       responses:
@@ -194,7 +194,7 @@ paths:
         - name: selectorId
           in: path
           required: true
-          description: The id of the selector to retrieve
+          description: The ID of the selector to retrieve
           schema:
             type: integer
       responses:
@@ -219,7 +219,7 @@ paths:
         - name: selectorId
           in: path
           required: true
-          description: The id of the selector to retrieve
+          description: The ID of the selector to retrieve
           schema:
             type: integer
       responses:
@@ -298,7 +298,7 @@ paths:
         - name: objectId
           in: path
           required: true
-          description: The id of the object to retrieve
+          description: The ID of the object to retrieve
           schema:
             type: integer
       responses:
@@ -323,7 +323,7 @@ paths:
         - name: objectId
           in: path
           required: true
-          description: The id of the object to retrieve
+          description: The ID of the object to retrieve
           schema:
             type: integer
       responses:
@@ -394,7 +394,7 @@ paths:
         - name: agentId
           in: path
           required: true
-          description: The id of the agent to retrieve
+          description: The ID of the agent to retrieve
           schema:
             type: integer
       responses:
@@ -419,7 +419,7 @@ paths:
         - name: agentId
           in: path
           required: true
-          description: The id of the agent to retrieve
+          description: The ID of the agent to retrieve
           schema:
             type: integer
       responses:
@@ -445,7 +445,7 @@ paths:
         - name: agentId
           in: path
           required: true
-          description: The id of the agent
+          description: The ID of the agent
           schema:
             type: integer
       requestBody:
@@ -551,73 +551,7 @@ paths:
         - name: communityId
           in: path
           required: true
-          description: The id of the community entry
-          schema:
-            type: integer
-      responses:
-        "204":
-          description: Null response
-        default:
-          description: Unspecified error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-
-  /agents/{agentId}/access:
-    description: >
-      This resource represents a SNMPv3 access entry (VACM) associated with
-      SNMP agent identified by `agentId`.
-    put:
-      summary: Add new SNMPv3 VACM entry
-      operationId: addVacm
-      tags:
-        - agents
-      parameters:
-        - name: agentId
-          in: path
-          required: true
-          description: The ID of the agent
-          schema:
-            type: integer
-      requestBody:
-        description: >
-          Receive a new SNMPv3 VACM entry
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Access'
-      responses:
-        "204":
-          description: Null response
-        default:
-          description: Unspecified error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-
-  /agents/{agentId}/access/{accessId}:
-    description: >
-      This resource represents a SNMPv3 access entry (VACM) associated with
-      SNMP agent identified by `agentId`.
-    delete:
-      summary: Add new SNMPv3 VACM entry
-      operationId: delVacm
-      tags:
-        - agents
-      parameters:
-        - name: agentId
-          in: path
-          required: true
-          description: The ID of the agent
-          schema:
-            type: integer
-        - name: accessId
-          in: path
-          required: true
-          description: The id of the VACM access entry
+          description: The ID of the community entry
           schema:
             type: integer
       responses:
@@ -712,7 +646,7 @@ paths:
         - name: labId
           in: path
           required: true
-          description: The id of the virtual laboratory
+          description: The ID of the virtual laboratory
           schema:
             type: integer
       responses:
@@ -744,7 +678,7 @@ paths:
         - name: agentId
           in: path
           required: true
-          description: The id of the SNMP agent
+          description: The ID of the SNMP agent
           schema:
             type: integer
       responses:
@@ -771,7 +705,7 @@ paths:
         - name: agentId
           in: path
           required: true
-          description: The id of the SNMP agent
+          description: The ID of the SNMP agent
           schema:
             type: integer
       responses:
@@ -821,59 +755,6 @@ paths:
 
 components:
   schemas:
-    Access:
-      description: >
-        SNMP managed objects are identified by OIDs. SNMP includes the accesss
-        control subsystem (known as VACM) that can "mask" some of the OIDs, in
-        the imaginary tree of sub-OID numbers, on per-user/protocol version
-        basis.
-      type: object
-      required:
-        - id
-        - subtree
-      properties:
-        id:
-          description: >
-            Access entry ID
-          type: integer
-          format: int64
-        subtree:
-          description: >
-            OID subtree that this entry applies access control on.
-          type: string
-          pattern: ".*"  # TODO OID regexp
-        mask:
-          description: >
-            An OID consisting of 1's and 0's to define branches of OID tree this
-            entry applies access control on. Technically, logical *AND* operation
-            is applied on `subree` and `mask` yielding access-significant sub-OIDs.
-          type: string
-          pattern: ".*"  # TODO OID regexp
-        protocol:
-          description: >
-            SNMP protocol version this entry is applicable to
-          type: string
-          enum: [v1, v2c, v3]
-        security:
-          description: >
-            SNMP security level this entry is applicable to
-          type: string
-          enum: [noAuthNoPriv, authNoPriv, authPriv]
-        mode:
-          description: >
-            SNMP operation this entry is applicable to
-          type: string
-          enum: [read, write, notify]
-        context:
-          description: >
-            SNMP context name this entry is applicable to.
-          type: string
-        partial:
-          description: >
-            If true, match `context` as SNMP context name prefix rather than
-            matching exactly.
-          type: boolean
-
     User:
       description: >
         SNMPv3 USM user entry. Contains SNMPv3 credentials grouped by
@@ -887,30 +768,39 @@ components:
             User entry ID
           type: integer
           format: int64
-        username:
+        name:
           description: >
-            USM user name
+            SNMP security name of this entry.
+          type: string
+        level:
+          description: >
+            SNMP security level.
+          type: string
+          enum: [noAuthNoPriv, authNoPriv, authPriv]
+        user:
+          description: >
+            USM user name.
           type: string
           minLength: 1
           maxLength: 32
-        v3AuthKey:
+        authKey:
           description: >
             USM user authentication key
           type: string
           minLength: 8
           maxLength: 32
-        v3AuthProtocol:
+        authProtocol:
           description: >
             User authentication protocol
           type: string
           enum: [md5, sha, sha224, sha256, sha384, sha512, none]
-        v3PrivKey:
+        privKey:
           description: >
             USM user privacy (encryption) key
           type: string
           minLength: 8
           maxLength: 32
-        v3PrivProtocol:
+        privProtocol:
           type: string
           enum: [des, 3des, aes, aes128, aes192, aes192blmt, aes256,
                  aes256blmt, none]
@@ -930,6 +820,15 @@ components:
           type: integer
           format: int64
         name:
+          description: >
+            SNMP security name of this entry.
+          type: string
+        model:
+          description: >
+            SNMP security model.
+          type: string
+          enum: [v1, v2c]
+        community:
           type: string
 
     Engine:
@@ -953,10 +852,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Community"
-        access:
-          type: array
-          items:
-            $ref: "#/components/schemas/Access"
 
     Endpoint:
       description: >
@@ -1086,35 +981,49 @@ components:
             Descriptive name of this selector e.g. "agentA at endpointB when
             queried from addressC using SNMP community `secret`"
           type: string
-        contextEngineIds:
+        contextEngineId:
           description: >
             This context is applicable for queries for this SNMP context engine ID.
             Empty value matches SNMP engine ID of SNMP engine considering this
             selector.
-          type: array
-          items:
-            type: string
-        contextNames:
+          type: string
+        contextName:
           description: >
             This context is applicable for queries for this SNMP context name.
-          type: array
-          items:
-            type: string
-        endpoints:
+          type: string
+        endpoint:
           description: >
-            This context is applicable for queries coming via these endpoints.
+            This context is applicable for queries coming via this endpoint.
             Empty value matches any endpoint.
-          type: array
-          items:
-            type: integer
-            format: int64
+          type: integer
+          format: int64
         source:
           description: >
-            This context is applicable for queries coming from these network addresses.
-            Empty value matches any source.
-          type: array
-          items:
-            type: string
+            This context is applicable for queries coming from this network
+            address. Empty value matches any source.
+          type: string
+        model:
+          description: >
+            This context is applicable for queries coming over this SNMP
+            security model.
+          type: string
+          enum: [v1, v2c, any]
+        level:
+          description: >
+            This context is applicable for queries coming at this SNMP security
+            level.
+          type: string
+          enum: [noAuthNoPriv, authNoPriv, authPriv, any]
+        username:
+          description: >
+            This context is applicable for queries coming with this SNMPv3 USM
+            user name. Empty value matches any user name.
+          type: string
+        community:
+          description: >
+            This context is applicable for queries coming with this SNMPv1/v2c
+            community name. Empty value matches any community name.
+          type: string
         recordings:
           description: >
             ID of SNMP recording associated with this selector.
@@ -1183,6 +1092,17 @@ components:
       items:
         $ref: "#/components/schemas/Lab"
 
+    LabPowerState:
+      description: >
+        Desired lab power state.
+      type: object
+      properties:
+        state:
+          description: >
+            Power state of all SNMP agents in this lab
+          type: string
+          enum: [up, down]
+
     Error:
       type: object
       required:
@@ -1194,14 +1114,3 @@ components:
           format: int32
         message:
           type: string
-
-    LabPowerState:
-      description: >
-        Desired lab power state.
-      type: object
-      properties:
-        state:
-          description: >
-            Power state of all SNMP agents in this lab
-          type: string
-          enum: [up, down]

--- a/docs/snmpsim-mgmt-api.yaml
+++ b/docs/snmpsim-mgmt-api.yaml
@@ -6,21 +6,21 @@ info:
   title: 'SNMP Simulator Control Plane REST API'
   description: >
     The Management API is designed to support complete SNMP Simulator work flow
-    remotely. As such, Management API supports SNMp entity (Agent) creation,
+    remotely. As such, Management API supports SNMP Agent creation,
     configuration and eventual tear down. Simulation data can be uploaded,
     modified, removed and exposed under different circumstances. On top of
-    that, SNMP agents can be grouped together to form "virtual labs" that
+    that, SNMP agents can be grouped together to form "virtual lab" that
     can be brought up/down altogether.
 
     Typical management work flow looks like this:
 
-    1. Create SNMP Agent using `/entities` REST API endpoint. You can supply
+    1. Create SNMP Agent using `/agents` REST API endpoint. You can supply
        complete agent configuration at once or add/modify it incrementally.
        Important configuration items include: SNMP Engine ID, SNMPv3 VACM
        user(s) credentials, SNMPv1/v2c community name(s)
     2. Create SNMP transport endpoint(s) using `/endpoints`. These are the
        address(es) where SNMP agent is listening for inbound SNMP commands.
-       When creating an endpoint, bind it to one specific SNMP entity.
+       When creating an endpoint, bind it to one specific SNMP agent.
     3. Create SNMP simulation data by uploading the entire `.snmprec` file
        via `/objects` endpoint. You can read/modify it on per-line basis
        later on.
@@ -29,8 +29,8 @@ info:
        be examined in specified order at the time of SNMP command processing.
        First selector matching request properties will be picked and
        associated simulation data will be used for answering the query.
-    5. Optionally, add your new SNMP entity to a new or existing group via
-       `/groups` endpoint.
+    5. Optionally, add your new SNMP agent to a new or existing lab via
+       `/labs` endpoint.
 
 servers:
   - url: https://virtserver.swaggerhub.com/etingof/snmpsimd-control-plane/1.0.0
@@ -40,7 +40,7 @@ paths:
     get:
       description: >
         This resource represents a list of all existing transport endpoints
-        that can be used by SNMP entities.
+        that can be used by SNMP agents.
       summary: >
         List all existing transport endpoints
       operationId: listEndpoints
@@ -67,7 +67,7 @@ paths:
         - endpoints
       requestBody:
         description: >
-          Receive a new endpoint object bound to an existing SNMP entity.
+          Receive a new endpoint object bound to an existing SNMP agent.
         required: true
         content:
           application/json:
@@ -232,24 +232,24 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /objects:
+  /recordings:
     description: >
-      This resource represents a collection of simulated data objects. Each
-      `object` in the collection corresponds to a single `.snmprec` file.
+      This resource represents a collection of simulation data recordings. Each
+      `recording` in the collection corresponds to a single `.snmprec` file.
     get:
       summary: >
-        List all existing simulation data objects.
-      operationId: listObjects
+        List all existing simulation data recordings.
+      operationId: listRecordings
       tags:
-        - objects
+        - recordings
       responses:
         "200":
           description: >
-            An array of simulation data objects
+            An array of simulation data recordings
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Objects"
+                $ref: "#/components/schemas/Recordings"
             text/plain:
               schema:
                 type: string
@@ -260,10 +260,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
     post:
-      summary: Create a new simulation data objects
-      operationId: createObject
+      summary: Create a new simulation data recording
+      operationId: createRecording
       tags:
-        - objects
+        - recordings
       requestBody:
         description: >
           Receive the entire .snmprec file in a JSON object or ASCII text form.
@@ -271,7 +271,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Object'
+              $ref: '#/components/schemas/Recording'
           text/plain:
             schema:
               type: string
@@ -285,15 +285,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /objects/{objectId}:
+  /recordings/{objectId}:
     description: >
-      This resource represents a single simulation data object identified
+      This resource represents a single simulation data recording identified
       by `objectId`.
     get:
       summary: Info for a specific simulation data object
-      operationId: showObjectsById
+      operationId: showRecordingById
       tags:
-        - objects
+        - recordings
       parameters:
         - name: objectId
           in: path
@@ -307,7 +307,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Object"
+                $ref: "#/components/schemas/Recording"
         default:
           description: unexpected error
           content:
@@ -316,9 +316,9 @@ paths:
                 $ref: "#/components/schemas/Error"
     delete:
       summary: Delete simulation data object
-      operationId: deleteObject
+      operationId: deleteRecording
       tags:
-        - objects
+        - recordings
       parameters:
         - name: objectId
           in: path
@@ -336,23 +336,23 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /entities:
+  /agents:
     description: >
-      This resource represents a list of all SNMP entities (agents).
+      This resource represents a list of all SNMP agents.
     get:
       summary: >
-        List all existing SNMP entities
-      operationId: listEntities
+        List all existing SNMP agents
+      operationId: listAgents
       tags:
-        - entities
+        - agents
       responses:
         "200":
           description: >
-            An array of SNMP entities
+            An array of SNMP agents
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Entities"
+                $ref: "#/components/schemas/Agents"
         default:
           description: Unspecified error
           content:
@@ -360,17 +360,17 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
     post:
-      summary: Create new SNMP entity
-      operationId: createEntity
+      summary: Create a new SNMP agent
+      operationId: createAgent
       tags:
-        - entities
+        - agents
       requestBody:
         description: >
-          New SNMP entity
+          New SNMP agent object
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Entity'
+              $ref: '#/components/schemas/Agent'
       responses:
         "201":
           description: Null response
@@ -381,20 +381,20 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /entities/{entityId}:
+  /agents/{agentId}:
     description: >
-      This resource represents a single SNMP entity (agent) identified
-      by `entityId`.
+      This resource represents a single SNMP agent identified
+      by `agentId`.
     get:
-      summary: Info for a specific SNMP entity
-      operationId: showEntityById
+      summary: Info for a specific SNMP agent
+      operationId: showAgentById
       tags:
-        - entities
+        - agents
       parameters:
-        - name: entityId
+        - name: agentId
           in: path
           required: true
-          description: The id of the entity to retrieve
+          description: The id of the agent to retrieve
           schema:
             type: integer
       responses:
@@ -403,7 +403,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Entity"
+                $ref: "#/components/schemas/Agent"
         default:
           description: unexpected error
           content:
@@ -411,15 +411,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
     delete:
-      summary: Delete SNMP entity
-      operationId: deleteEntity
+      summary: Delete SNMP agent
+      operationId: deleteAgent
       tags:
-        - entities
+        - agents
       parameters:
-        - name: entityId
+        - name: agentId
           in: path
           required: true
-          description: The id of the entity to retrieve
+          description: The id of the agent to retrieve
           schema:
             type: integer
       responses:
@@ -432,20 +432,20 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /entities/{entityId}/users:
+  /agents/{agentId}/users:
     description: >
       This resource represents a SNMPv3 USM user record associated with SNMP
-      entity identified by `entityId`.
+      agent identified by `agentId`.
     put:
       summary: Add new USM user entry
       operationId: addUsmUser
       tags:
-        - entities
+        - agents
       parameters:
-        - name: entityId
+        - name: agentId
           in: path
           required: true
-          description: The id of the entity
+          description: The id of the agent
           schema:
             type: integer
       requestBody:
@@ -466,26 +466,26 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /entities/{entityId}/users/{userId}:
+  /agents/{agentId}/users/{userId}:
     description: >
       This resource represents a SNMPv3 USM user record associated with SNMP
-      entity identified by `entityId`.
+      agent identified by `agentId`.
     delete:
       summary: Remove USM user entry
       operationId: delUsmUser
       tags:
-        - entities
+        - agents
       parameters:
-        - name: entityId
+        - name: agentId
           in: path
           required: true
-          description: The id of the entity
+          description: The ID of the agent
           schema:
             type: integer
         - name: userId
           in: path
           required: true
-          description: The id of the USM entry
+          description: The ID of the USM entry
           schema:
             type: integer
       responses:
@@ -498,20 +498,20 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /entities/{entityId}/communities:
+  /agents/{agentId}/communities:
     description: >
       This resource represents a SNMP community name record associated with
-      SNMP entity identified by `entityId`.
+      SNMP agent identified by `agentId`.
     put:
       summary: Add new SNMPv1/v2c community name
       operationId: addCommunity
       tags:
-        - entities
+        - agents
       parameters:
-        - name: entityId
+        - name: agentId
           in: path
           required: true
-          description: The id of the entity
+          description: The ID of the agent
           schema:
             type: integer
       requestBody:
@@ -532,20 +532,20 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /entities/{entityId}/communities/{communityId}:
+  /agents/{agentId}/communities/{communityId}:
     description: >
       This resource represents a SNMP community name record associated with
-      SNMP entity identified by `entityId`.
+      SNMP agent identified by `agentId`.
     delete:
       summary: Delete new SNMPv1/v2c community name
       operationId: delCommunity
       tags:
-        - entities
+        - agents
       parameters:
-        - name: entityId
+        - name: agentId
           in: path
           required: true
-          description: The id of the entity
+          description: The ID of the agent
           schema:
             type: integer
         - name: communityId
@@ -564,20 +564,20 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /entities/{entityId}/access:
+  /agents/{agentId}/access:
     description: >
       This resource represents a SNMPv3 access entry (VACM) associated with
-      SNMP entity identified by `entityId`.
+      SNMP agent identified by `agentId`.
     put:
       summary: Add new SNMPv3 VACM entry
       operationId: addVacm
       tags:
-        - entities
+        - agents
       parameters:
-        - name: entityId
+        - name: agentId
           in: path
           required: true
-          description: The id of the entity
+          description: The ID of the agent
           schema:
             type: integer
       requestBody:
@@ -598,20 +598,20 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /entities/{entityId}/access/{accessId}:
+  /agents/{agentId}/access/{accessId}:
     description: >
       This resource represents a SNMPv3 access entry (VACM) associated with
-      SNMP entity identified by `entityId`.
+      SNMP agent identified by `agentId`.
     delete:
       summary: Add new SNMPv3 VACM entry
       operationId: delVacm
       tags:
-        - entities
+        - agents
       parameters:
-        - name: entityId
+        - name: agentId
           in: path
           required: true
-          description: The id of the entity
+          description: The ID of the agent
           schema:
             type: integer
         - name: accessId
@@ -630,23 +630,23 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /groups:
+  /labs:
     get:
       description: >
-        This resource represents a list of all existing SNMP entity groups.
+        This resource represents a list of all existing virtual laboratories.
       summary: >
-        List all existing SNMP entity groups
-      operationId: listGroups
+        List all existing virtual laboratories
+      operationId: listLabs
       tags:
-        - groups
+        - labs
       responses:
         "200":
           description: >
-            An array of SNMP entity groups
+            An array of virtual laboratories
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Groups"
+                $ref: "#/components/schemas/Labs"
         default:
           description: Unspecified error
           content:
@@ -654,17 +654,17 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
     post:
-      summary: Create new SNMP entity group
-      operationId: createGroup
+      summary: Create new virtual laboratory
+      operationId: createLab
       tags:
-        - groups
+        - labs
       requestBody:
         description: >
-          New group optionally containing SNMP entity IDs.
+          New lab optionally containing SNMP agent IDs.
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Group'
+              $ref: '#/components/schemas/Lab'
       responses:
         "201":
           description: Null response
@@ -675,19 +675,19 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /groups/{groupId}:
+  /labs/{labId}:
     description: >
-      This resource represents a SNMP entity group identified by `groupId`.
+      This resource represents a virtual laboratory identified by `labId`.
     get:
       summary: Info for a specific SNMP transport endpoint
-      operationId: showGroupById
+      operationId: showLabById
       tags:
-        - groups
+        - labs
       parameters:
-        - name: groupId
+        - name: labId
           in: path
           required: true
-          description: The id of the SNMP entity group
+          description: The ID of the virtual laboratory
           schema:
             type: integer
       responses:
@@ -696,7 +696,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Group"
+                $ref: "#/components/schemas/Lab"
         default:
           description: unexpected error
           content:
@@ -704,15 +704,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
     delete:
-      summary: Delete SNMP entity grouping
-      operationId: deleteGroup
+      summary: Delete virtual laboratory
+      operationId: deleteLab
       tags:
-        - groups
+        - labs
       parameters:
-        - name: groupId
+        - name: labId
           in: path
           required: true
-          description: The id of the SNMP entity group
+          description: The id of the virtual laboratory
           schema:
             type: integer
       responses:
@@ -725,26 +725,26 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /groups/{groupId}/entity/{entityId}:
+  /labs/{labId}/agent/{agentId}:
     description: >
-      This resource represents a SNMP entity identified by `entityId`
-      associated with group identified by `groupId`.
+      This resource represents a SNMP agent identified by `agentId`
+      associated with a virtual laboratory identified by `labId`.
     put:
-      summary: Add existing SNMP entity to group
-      operationId: addToGroup
+      summary: Add existing SNMP agent to a virtual laboratory
+      operationId: addToLab
       tags:
-        - groups
+        - labs
       parameters:
-        - name: groupId
+        - name: labId
           in: path
           required: true
-          description: The id of the SNMP entity group
+          description: The ID of the virtual laboratory
           schema:
             type: integer
-        - name: entityId
+        - name: agentId
           in: path
           required: true
-          description: The id of the SNMP entity
+          description: The id of the SNMP agent
           schema:
             type: integer
       responses:
@@ -757,21 +757,21 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
     delete:
-      summary: Remove SNMP entity from group
-      operationId: delFromGroup
+      summary: Remove SNMP agent from the virtual laboratory
+      operationId: delFromLab
       tags:
-        - groups
+        - labs
       parameters:
-        - name: groupId
+        - name: labId
           in: path
           required: true
-          description: The id of the SNMP entity group
+          description: The ID of the virtual laboratory
           schema:
             type: integer
-        - name: entityId
+        - name: agentId
           in: path
           required: true
-          description: The id of the SNMP entity
+          description: The id of the SNMP agent
           schema:
             type: integer
       responses:
@@ -784,30 +784,31 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /groups/{groupId}/power:
+  /labs/{labId}/power:
     description: >
-      This resource represents group power state. The group is identified by
-      `groupId`, power state can be queried and modified.
+      This resource represents the power state of the entire virtual laboratory.
+      The virtual laboratory is identified by `labId`, power state can be
+      queried and modified.
     put:
-      summary: Change group power state
-      operationId: setGroupPowerState
+      summary: Change power state of the virtual laboratory
+      operationId: setLabPowerState
       tags:
-        - groups
+        - labs
       parameters:
-        - name: groupId
+        - name: labId
           in: path
           required: true
-          description: The id of the SNMP entity group
+          description: The ID of the virtual laboratory
           schema:
             type: integer
       requestBody:
         description: >
-          Carries desired group power state
+          Carries desired power state of the virtual laboratory
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GroupPowerState'
+              $ref: '#/components/schemas/LabPowerState'
       responses:
         "204":
           description: Null response
@@ -936,10 +937,12 @@ components:
         Represents a unique, independent and fully operational SNMP engine, though
         not yet attached to any transport endpoints.
       type: object
-      required:
-        - engineId
       properties:
         engineId:
+          description: >
+            Administratively assigned, unique (within an administrative domain) ID
+            of SNMP engine. Newly created objects missing this field will have it
+            autogenerated.
           type: string
           pattern: ".*"  # TODO: three distinct formats
         users:
@@ -971,9 +974,13 @@ components:
             Transport endpoint unique ID
           type: integer
           format: int64
-        entityId:
+        name:
           description: >
-            SNMP entity ID binding this endpoint
+            Descriptive name of this transport endpoint e.g. "port123 at vif456"
+          type: string
+        agentId:
+          description: >
+            SNMP agent ID binding this endpoint
           type: integer
           format: int64
         domain:
@@ -990,12 +997,14 @@ components:
       items:
         $ref: "#/components/schemas/Endpoint"
 
-    Object:
+    Record:
       description: >
-        SNMP managed object instance. On SNMP side of things, managed object
-        instance is identified by a unique OID and, sometimes, an associated
-        value representing the state of the backend application object being
-        managed via SNMP.
+        SNMP record representing a single line of `.snmprec` file. In SNMP
+        parlance it's also known as SNMP managed object instance.
+
+        On SNMP side of things, managed object instance is identified
+        by a unique OID and, sometimes, an associated value representing the
+        state of the backend application object being managed via SNMP.
 
         Depending on the nature of the managed object, associated value can
         be settable and/or modifiable.
@@ -1010,44 +1019,59 @@ components:
           format: int64
         oid:
           description: >
-            OID associated with this managed object instance
+            OID associated with this SNMP managed object instance
           type: string
           pattern: ".*"  # TODO OID regexp
         type:
           description: >
-            SNMP type of the value assocated with this managed object.
+            SNMP type of the value associated with this managed object instance.
           type: string
           enum: [integer32, octetstring, counter32, counter64, gauge32,
                  opaque, ipaddress, null, timeticks]
         value:
           description: >
-            Static value returned by this managed object
+            Static value returned by this managed object instance
           type: string
         variation:
           description: >
-            Variation module invoked when serving this managed object
+            Variation module invoked when serving this managed object instance
           type: string
           enum: [numeric, error, delay, notification, multiplex, redis,
                  sql, subprocess, writecache]
         variationOptions:
           type: string
 
-    Objects:
+    Recording:
       description: >
-        Ordered collection of SNMP managed objects
+        Ordered collection of SNMP records representing a single `.snmprec`
+        file.
+      type: object
+      properties:
+        name:
+          description: >
+            Descriptive name of this recording e.g. "cisco5300 routing and L2 tables"
+          type: string
+        records:
+          type: array
+          items:
+            $ref: "#/components/schemas/Record"
+
+    Recordings:
+      description: >
+        A collection of SNMP recordings
       type: object
       properties:
         id:
           type: integer
           format: int64
-        objects:
+        recordings:
           type: array
           items:
-            $ref: "#/components/schemas/Object"
+            $ref: "#/components/schemas/Recording"
 
     Selector:
       description: >
-        Set of rules for SNMP entity to choose SNMP managed objects collection
+        Set of rules for SNMP agent to choose recordings collection
         associated with this selector. All of the fields in the selector must
         match for this selector to be chosen.
       type: object
@@ -1057,6 +1081,11 @@ components:
         id:
           type: integer
           format: int64
+        name:
+          description: >
+            Descriptive name of this selector e.g. "agentA at endpointB when
+            queried from addressC using SNMP community `secret`"
+          type: string
         contextEngineIds:
           description: >
             This context is applicable for queries for this SNMP context engine ID.
@@ -1086,65 +1115,73 @@ components:
           type: array
           items:
             type: string
-        objects:
+        recordings:
           description: >
-            ID of SNMP managed objects collection associated with this selector.
+            ID of SNMP recording associated with this selector.
           type: integer
           format: int64
 
     Selectors:
       description: >
-        Ordered list of selector IDs for SNMP entity to consider. First match
+        Ordered list of selector IDs for SNMP agent to consider. First match
         satisfies the query.
       type: array
       items:
         $ref: "#/components/schemas/Selector"
 
-    Entity:
+    Agent:
       description: >
-        SNMP entity or SNMP agent. Consists of SNMP engine and transport
+        Represents SNMP agent. Consists of SNMP engine and transport
         endpoints it binds.
       type: object
       properties:
         id:
           type: integer
           format: int64
+        name:
+          description: >
+            Descriptive name of this agent e.g. "cisco5300"
+          type: string
         engine:
           $ref: "#/components/schemas/Engine"
 
-    Entities:
+    Agents:
       type: array
       items:
-        $ref: "#/components/schemas/Entity"
+        $ref: "#/components/schemas/Agent"
 
-    Group:
+    Lab:
       description: >
-        Group of SNMP entities. Some operations can be applied to them all
-        at once.
+        Group of SNMP agents belonging to the same virtual laboratory. Some
+        operations can be applied to them all at once.
       type: object
       properties:
         id:
           type: integer
           format: int64
-        entities:
+        name:
           description: >
-            SNMP entities IDs belonging to this group
+            Descriptive name of this lab e.g. "cisco switching shop"
+          type: string
+        agents:
+          description: >
+            SNMP agent IDs belonging to this lab
           type: array
           items:
             type: integer
             format: int64
         state:
           description: >
-            State of SNMP entities in this group
+            State of SNMP agents in this lab
           type: string
           enum: [up, down]
 
-    Groups:
+    Labs:
       description: >
-        A collection of groups of SNMP entities.
+        A collection of virtual laboratories.
       type: array
       items:
-        $ref: "#/components/schemas/Group"
+        $ref: "#/components/schemas/Lab"
 
     Error:
       type: object
@@ -1158,13 +1195,13 @@ components:
         message:
           type: string
 
-    GroupPowerState:
+    LabPowerState:
       description: >
-        Desired group power state.
+        Desired lab power state.
       type: object
       properties:
         state:
           description: >
-            Power state of all SNMP entities in this group
+            Power state of all SNMP agents in this lab
           type: string
           enum: [up, down]

--- a/docs/snmpsim-monitoring-api.yaml
+++ b/docs/snmpsim-monitoring-api.yaml
@@ -10,20 +10,43 @@ info:
     The data is provided by running SNMP Simulator, REST API is essentially
     read-only.
 
+
     The `/processes` endpoint exposes the details on SNMP simulator health
     as a set of UNIX processes. It's mostly concern with processes being
     present, resources being consumed reasonably and internal faults noted.
+
 
     Typical use of the `/processes` endpoint by some monitoring application
     can be a parameterized REST API call designed to reveal missing processes,
     overly consumed system resources or serious application-specific errors
     occurring in SNMP simulator.
 
-    The `/subsystems` endpoint is all about SNMP traffic being handled by
-    certain simulator subsystem. Provided data is mostly ever increasing
-    counters reflecting the activity of the subsystem. The consumer of this
-    endpoint is expected to poll it periodically pushing collected data
-    into a time-series database for dynamics computing and data aggregation.
+
+    The `/activity` endpoint is all about SNMP
+    traffic being handled by certain simulator
+    subsystem. Conceptually, any SNMP command
+    traverses simulator subsystems in order
+
+    * transport endpoint
+
+    * agent
+
+    * recording
+
+
+    Reported data reflects cumulative SNMP traffic
+    optionally selected by any subsystem.
+
+
+    For example, the user can get packet count for all agents or for a single
+    specific agent, for agent+endpoint combination (an agent can listen on
+    multiple endpoints) or for agent+recording pair (any single recording can
+    be used by many agents).
+
+
+    The consumer of this endpoint is expected to poll it periodically pushing
+    collected data into a time-series database for dynamics computing and data
+    aggregation.
 
 servers:
   - url: https://virtserver.swaggerhub.com/etingof/snmpsimd-monitoring/1.0.0
@@ -84,164 +107,45 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /subsystems/agents:
+  /activity:
     get:
       description: >
-        Activity report for all agents.
-      summary: >
-        Live agents activity report.
-      operationId: listAgents
+        Activity report for a selection of agents / endpoints / recordings.
+      operationId: listActivity
       tags:
-        - agents
-      responses:
-        '200':
-          description: Agents activity report object
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Subsystems"
-        default:
-          description: Unspecified error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-
-  /subsystems/agents/{agentId}:
-    get:
-      description: >
-        Activity report for a selected agent.
-      summary: >
-        Live agent activity report.
-      operationId: listAgent
-      tags:
-        - agents
+        - activity
       parameters:
         - name: agentId
-          in: path
+          in: query
           description: >
             Report activity for the agent with this `name`. A single agent can
             listen on multiple transport endpoints.
-          required: true
+          required: false
           schema:
             type: string
-      responses:
-        '200':
-          description: Agent activity report object
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Subsystem"
-        default:
-          description: Unspecified error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-
-  /subsystems/endpoints:
-    get:
-      description: >
-        Activity report for all endpoints.
-      summary: >
-        Live endpoints activity report.
-      operationId: listEndpoints
-      tags:
-        - endpoints
-      responses:
-        '200':
-          description: Endpoints activity report object
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Subsystems"
-        default:
-          description: Unspecified error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-
-  /subsystems/endpoints/{endpointId}:
-    get:
-      description: >
-        Activity report for a selected transport endpoint.
-      summary: >
-        Live endpoint activity report.
-      operationId: listEndpoint
-      tags:
-        - endpoints
-      parameters:
         - name: endpointId
-          in: path
+          in: query
           description: >
             Report activity for transport endpoint with this `name`. Only one
             agent can listen on any single endpoint.
-          required: true
+          required: false
           schema:
             type: string
-      responses:
-        '200':
-          description: Endpoint activity report object
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Subsystem"
-        default:
-          description: Unspecified error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-
-  /subsystems/recordings:
-    get:
-      description: >
-        Activity report for all recordings.
-      summary: >
-        Live recordings activity report.
-      operationId: listRecordings
-      tags:
-        - recordings
-      responses:
-        '200':
-          description: Recordings activity report object
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Subsystems"
-        default:
-          description: Unspecified error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-
-  /subsystems/recordings/{recordingId}:
-    get:
-      description: >
-        Activity report for a selected recording.
-      summary: >
-        Live recording activity report.
-      operationId: listRecording
-      tags:
-        - recordings
-      parameters:
         - name: recordingId
-          in: path
+          in: query
           description: >
             Report activity for recording with this `name`. Multiple
             agents can hit any single recording.
-          required: true
+          required: false
           schema:
             type: string
       responses:
         '200':
-          description: Recording activity report object
+          description: Activity object
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Subsystem"
+                $ref: "#/components/schemas/Activity"
         default:
           description: Unspecified error
           content:
@@ -251,9 +155,10 @@ paths:
 
 components:
   schemas:
-    Subsystem:
+    Activity:
       description: >
-        Activity information for a single subsystem such as agent/endpoint/recording.
+        Activity information for an agent/endpoint/recording or their
+        sums/combinations.
       type: object
       properties:
         name:
@@ -262,29 +167,41 @@ components:
           type: integer
         last_hit:
           type: integer
-        counters:
+        get:
           $ref: "#/components/schemas/Counters"
-
-    Subsystems:
-      description: >
-        An array of subsystem activity information.
-      type: array
-      items:
-        $ref: "#/components/schemas/Subsystem"
+        set:
+          $ref: "#/components/schemas/Counters"
+        getnext:
+          $ref: "#/components/schemas/Counters"
+        getbulk:
+          $ref: "#/components/schemas/Counters"
 
     Counters:
       description: >
-        Activity counters.
+        Activity counters since system initialization.
       type: object
       properties:
-        successful:
+        total:
           description: >
-            Number of successful operations since system initialization
+            Total number of requests.
           type: integer
-        errored:
+          format: int64
+        protocol_errors:
           description: >
-            Number of failed operations since system initialization
+            Number of protocol-level failures.
           type: integer
+          format: int64
+        routing_errors:
+          description: >
+            Number of requests that can't be routed to a recording.
+          type: integer
+          format: int64
+        data_errors:
+          description: >
+            Number of requests that failed on recording data accommodation
+            including variation modules failures.
+          type: integer
+          format: int64
 
     Process:
       description: >

--- a/docs/snmpsim-monitoring-api.yaml
+++ b/docs/snmpsim-monitoring-api.yaml
@@ -19,12 +19,11 @@ info:
     overly consumed system resources or serious application-specific errors
     occurring in SNMP simulator.
 
-    The `/messages` endpoint is all about SNMP traffic being handled. This
-    endpoint can report passing SNMP traffic in great details. Built-in
-    filtering allows selecting just certain aspects of SNMP exchange. For
-    example, the user can inspect SNMP traffic belonging to one particular
-    manager or agent, SNMP commands with specific user or community name
-    etc.
+    The `/subsystems` endpoint is all about SNMP traffic being handled by
+    certain simulator subsystem. Provided data is mostly ever increasing
+    counters reflecting the activity of the subsystem. The consumer of this
+    endpoint is expected to poll it periodically pushing collected data
+    into a time-series database for dynamics computing and data aggregation.
 
 servers:
   - url: https://virtserver.swaggerhub.com/etingof/snmpsimd-monitoring/1.0.0
@@ -85,114 +84,164 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /messages:
+  /subsystems/agents:
     get:
       description: >
-        Paged collection of messages ordered from most recent.
+        Activity report for all agents.
       summary: >
-        Search for and list messages
-      operationId: listMessages
+        Live agents activity report.
+      operationId: listAgents
       tags:
-        - messages
+        - agents
+      responses:
+        '200':
+          description: Agents activity report object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Subsystems"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /subsystems/agents/{agentId}:
+    get:
+      description: >
+        Activity report for a selected agent.
+      summary: >
+        Live agent activity report.
+      operationId: listAgent
+      tags:
+        - agents
       parameters:
-        - name: id
-          in: query
+        - name: agentId
+          in: path
           description: >
-            Select message with this ID
-          required: false
-          schema:
-            type: integer
-        - name: worker
-          in: query
-          description: >
-            Select messages handled by this worker process.
-          required: false
-          schema:
-            type: integer
-        - name: older
-          in: query
-          description: >
-            Select messages older than specified
-          required: false
-          schema:
-            type: integer
-        - name: newer
-          in: query
-          description: >
-            Select messages newer than specified
-          required: false
-          schema:
-            type: integer
-        - name: transport
-          in: query
-          description: >
-            Select messages arrived via specified transport
-          required: false
-          schema:
-            type: string
-        - name: source
-          in: query
-          description: >
-            Select messages arrived from specified address
-          required: false
-          schema:
-            type: string
-        - name: destination
-          in: query
-          description: >
-            Select messages arrived to specified address
-          required: false
-          schema:
-            type: string
-        - name: model
-          in: query
-          description: >
-            Select messages sent over specified SNMP security model (version).
-          required: false
-          schema:
-            type: string
-            enum: [v1, v2c, v3]
-        - name: level
-          in: query
-          description: >
-            Select messages sent using specified SNMP security level.
-          required: false
-          schema:
-            type: string
-            enum: [noAuthNoPriv, authNoPriv, authPriv]
-        - name: user
-          in: query
-          description: >
-            Select messages sent in behalf of specified SNMPv3 USM user
-          required: false
-          schema:
-            type: string
-        - name: community
-          in: query
-          description: >
-            Select messages sent using specified SNMPv1/v2c community name
-          required: false
-          schema:
-            type: string
-        - name: tag
-          in: query
-          description: >
-            Select messages having this tag present among its tags.
-          required: false
+            Report activity for the agent with this `name`. A single agent can
+            listen on multiple transport endpoints.
+          required: true
           schema:
             type: string
       responses:
         '200':
-          description: Paged array of message objects
-          headers:
-            x-next:
-              description: A link to the next page of responses
-              schema:
-                type: string
+          description: Agent activity report object
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Messages"
+                $ref: "#/components/schemas/Subsystem"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /subsystems/endpoints:
+    get:
+      description: >
+        Activity report for all endpoints.
+      summary: >
+        Live endpoints activity report.
+      operationId: listEndpoints
+      tags:
+        - endpoints
+      responses:
+        '200':
+          description: Endpoints activity report object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Subsystems"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /subsystems/endpoints/{endpointId}:
+    get:
+      description: >
+        Activity report for a selected transport endpoint.
+      summary: >
+        Live endpoint activity report.
+      operationId: listEndpoint
+      tags:
+        - endpoints
+      parameters:
+        - name: endpointId
+          in: path
+          description: >
+            Report activity for transport endpoint with this `name`. Only one
+            agent can listen on any single endpoint.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Endpoint activity report object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Subsystem"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /subsystems/recordings:
+    get:
+      description: >
+        Activity report for all recordings.
+      summary: >
+        Live recordings activity report.
+      operationId: listRecordings
+      tags:
+        - recordings
+      responses:
+        '200':
+          description: Recordings activity report object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Subsystems"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /subsystems/recordings/{recordingId}:
+    get:
+      description: >
+        Activity report for a selected recording.
+      summary: >
+        Live recording activity report.
+      operationId: listRecording
+      tags:
+        - recordings
+      parameters:
+        - name: recordingId
+          in: path
+          description: >
+            Report activity for recording with this `name`. Multiple
+            agents can hit any single recording.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Recording activity report object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Subsystem"
         default:
           description: Unspecified error
           content:
@@ -202,157 +251,40 @@ paths:
 
 components:
   schemas:
-    Message:
+    Subsystem:
       description: >
-        SNMP message lifecycle record
+        Activity information for a single subsystem such as agent/endpoint/recording.
       type: object
       properties:
-        id:
+        name:
+          type: string
+        first_hit:
           type: integer
-          format: int64
-        worker:
-          description: >
-            ID of the worker process handling this message.
+        last_hit:
           type: integer
-          format: int64
-        time:
-          description: >
-            When this message has arrived
-          type: integer
-        transport:
-          type: string
-          enum: [udpv4, udpv6]
-        source:
-          description: >
-            Network address from which this message has been received by
-            Simulator
-          type: string
-        destination:
-          description: >
-            Network address at which this message has been received by
-            Simulator
-          type: string
-        engineId:
-          description: >
-            SNMP engine ID of the SNMP engine receiving this message.
-          type: string
-          pattern: ".*"  # TODO: three distinct formats
-        model:
-          description: >
-            SNMP security model (protocol) being used.
-          type: string
-          enum: [v1, v2c, v3]
-        level:
-          description: >
-            SNMP security level being used.
-          type: string
-          enum: [noAuthNoPriv, authNoPriv, authPriv]
-        user:
-          description: >
-            SNMPv3 USM username passed in request
-          type: string
-        community:
-          description: >
-            SNMPv1/v2c passed in request
-          type: string
-        payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              format: int32
-            request:
-              $ref: "#/components/schemas/VarBinds"
-            response:
-              $ref: "#/components/schemas/VarBinds"
-        record:
-          description: >
-            Human friendly representation of the simulation data item
-            being used for answering this query.
-          type: object
-          properties:
-            name:
-              type: string
-        raw:
-          description: >
-            Raw SNMP packets as in the wire.
-          type: object
-          properties:
-            inbound:
-              type: string
-            outbound:
-              type: string
-        status:
-          $ref: "#/components/schemas/MessageStatus"
-        tags:
-          description: >
-            Free form tags set by the Simulator to assist grouping/searching.
-            Tags can include IDs of the agent that handled this message and
-            ID of the recording collection used to form the response.
-          type: array
-          items:
-            type: string
+        counters:
+          $ref: "#/components/schemas/Counters"
 
-    MessageStatus:
+    Subsystems:
       description: >
-        SNMP request outcome
-      type: object
-      properties:
-        result:
-          type: string
-          enum: [OK, FAILED]
-        category:
-          description: >
-            On failure, where exactly it failed
-          type: string
-          enum: [user, community, signature, cipher, parser, access, object,
-                 routing, variation, other]
-        details:
-          description: >
-            On failure, unstructured message explaining the cause
-          type: string
-
-    VarBind:
-      description: >
-        A single SNMP PDU variable-binding.
-      type: object
-      required:
-        - oid
-        - type
-        - value
-      properties:
-        oid:
-          description: >
-            OID associated with this SNMP managed object instance
-          type: string
-          pattern: ".*"  # TODO OID regexp
-        type:
-          description: >
-            SNMP type of the value associated with this managed object instance.
-          type: string
-          enum: [integer32, octetstring, counter32, counter64, gauge32,
-                 opaque, ipaddress, null, timeticks]
-        value:
-          description: >
-            Static value returned by this managed object instance
-          type: string
-
-    VarBinds:
-      description: >
-        An ordered collection of SNMP PDU variable-binding pairs
-      type: object
-      properties:
-        elements:
-          type: array
-          items:
-            $ref: "#/components/schemas/VarBind"
-
-    Messages:
-      description: >
-        An array of messages.
+        An array of subsystem activity information.
       type: array
       items:
-        $ref: "#/components/schemas/Message"
+        $ref: "#/components/schemas/Subsystem"
+
+    Counters:
+      description: >
+        Activity counters.
+      type: object
+      properties:
+        successful:
+          description: >
+            Number of successful operations since system initialization
+          type: integer
+        errored:
+          description: >
+            Number of failed operations since system initialization
+          type: integer
 
     Process:
       description: >

--- a/docs/snmpsim-monitoring-api.yaml
+++ b/docs/snmpsim-monitoring-api.yaml
@@ -3,9 +3,9 @@ info:
   license:
     name: BSD License
   version: '1.0.0'
-  title: 'SNMP Simulator Status REST API'
+  title: 'SNMP Simulator Monitoring REST API'
   description: >
-    Status API provides the insight for the operator to how SNMP Simulator
+    Monitoring API provides the insight for the operator to how SNMP Simulator
     is doing. That includes health reporting and operational statistics.
     The data is provided by running SNMP Simulator, REST API is essentially
     read-only.
@@ -27,7 +27,7 @@ info:
     etc.
 
 servers:
-  - url: https://virtserver.swaggerhub.com/etingof/snmpsimd-status-plane/1.0.0
+  - url: https://virtserver.swaggerhub.com/etingof/snmpsimd-monitoring/1.0.0
 
 paths:
   /processes:

--- a/docs/snmpsim-status-api.yaml
+++ b/docs/snmpsim-status-api.yaml
@@ -1,0 +1,421 @@
+openapi: 3.0.0
+info:
+  license:
+    name: BSD License
+  version: '1.0.0'
+  title: 'SNMP Simulator Status REST API'
+  description: >
+    Status API provides the insight for the operator to how SNMP Simulator
+    is doing. That includes health reporting and operational statistics.
+    The data is provided by running SNMP Simulator, REST API is essentially
+    read-only.
+
+    The `/processes` endpoint exposes the details on SNMP simulator health
+    as a set of UNIX processes. It's mostly concern with processes being
+    present, resources being consumed reasonably and internal faults noted.
+
+    Typical use of the `/processes` endpoint by some monitoring application
+    can be a parameterized REST API call designed to reveal missing processes,
+    overly consumed system resources or serious application-specific errors
+    occurring in SNMP simulator.
+
+    The `/messages` endpoint is all about SNMP traffic being handled. This
+    endpoint can report passing SNMP traffic in great details. Built-in
+    filtering allows selecting just certain aspects of SNMP exchange. For
+    example, the user can inspect SNMP traffic belonging to one particular
+    manager or agent, SNMP commands with specific user or community name
+    etc.
+
+servers:
+  - url: https://virtserver.swaggerhub.com/etingof/snmpsimd-status-plane/1.0.0
+
+paths:
+  /processes:
+    get:
+      description: >
+        Collection of SNMP simulator system process information.
+      summary: >
+        Search for and list process information.
+      operationId: listProcesses
+      tags:
+        - processes
+      parameters:
+        - name: newer
+          in: query
+          description: >
+            Select processes with uptime lesser than specified.
+          required: false
+          schema:
+            type: integer
+        - name: larger
+          in: query
+          description: >
+            Select processes with the amount of consumed memory larger
+            than specified.
+          required: false
+          schema:
+            type: integer
+        - name: hotter
+          in: query
+          description: >
+            Select processes with CPU utilization higher than specified.
+          required: false
+          schema:
+            type: integer
+        - name: sicker
+          in: query
+          description: >
+            Select processes with fatal, critical and warning counters
+            greater than specified.
+          required: false
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: >
+            An array of process information objects
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Processes"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /messages:
+    get:
+      description: >
+        Paged collection of messages ordered from most recent.
+      summary: >
+        Search for and list messages
+      operationId: listMessages
+      tags:
+        - messages
+      parameters:
+        - name: id
+          in: query
+          description: >
+            Select message with this ID
+          required: false
+          schema:
+            type: integer
+        - name: worker
+          in: query
+          description: >
+            Select messages handled by this worker process.
+          required: false
+          schema:
+            type: integer
+        - name: older
+          in: query
+          description: >
+            Select messages older than specified
+          required: false
+          schema:
+            type: integer
+        - name: newer
+          in: query
+          description: >
+            Select messages newer than specified
+          required: false
+          schema:
+            type: integer
+        - name: transport
+          in: query
+          description: >
+            Select messages arrived via specified transport
+          required: false
+          schema:
+            type: string
+        - name: source
+          in: query
+          description: >
+            Select messages arrived from specified address
+          required: false
+          schema:
+            type: string
+        - name: destination
+          in: query
+          description: >
+            Select messages arrived to specified address
+          required: false
+          schema:
+            type: string
+        - name: model
+          in: query
+          description: >
+            Select messages sent over specified SNMP security model (version).
+          required: false
+          schema:
+            type: string
+            enum: [v1, v2c, v3]
+        - name: level
+          in: query
+          description: >
+            Select messages sent using specified SNMP security level.
+          required: false
+          schema:
+            type: string
+            enum: [noAuthNoPriv, authNoPriv, authPriv]
+        - name: user
+          in: query
+          description: >
+            Select messages sent in behalf of specified SNMPv3 USM user
+          required: false
+          schema:
+            type: string
+        - name: community
+          in: query
+          description: >
+            Select messages sent using specified SNMPv1/v2c community name
+          required: false
+          schema:
+            type: string
+        - name: tag
+          in: query
+          description: >
+            Select messages having this tag present among its tags.
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Paged array of message objects
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Messages"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+components:
+  schemas:
+    Message:
+      description: >
+        SNMP message lifecycle record
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        worker:
+          description: >
+            ID of the worker process handling this message.
+          type: integer
+          format: int64
+        time:
+          description: >
+            When this message has arrived
+          type: integer
+        transport:
+          type: string
+          enum: [udpv4, udpv6]
+        source:
+          description: >
+            Network address from which this message has been received by
+            Simulator
+          type: string
+        destination:
+          description: >
+            Network address at which this message has been received by
+            Simulator
+          type: string
+        engineId:
+          description: >
+            SNMP engine ID of the SNMP engine receiving this message.
+          type: string
+          pattern: ".*"  # TODO: three distinct formats
+        model:
+          description: >
+            SNMP security model (protocol) being used.
+          type: string
+          enum: [v1, v2c, v3]
+        level:
+          description: >
+            SNMP security level being used.
+          type: string
+          enum: [noAuthNoPriv, authNoPriv, authPriv]
+        user:
+          description: >
+            SNMPv3 USM username passed in request
+          type: string
+        community:
+          description: >
+            SNMPv1/v2c passed in request
+          type: string
+        payload:
+          type: object
+          properties:
+            id:
+              type: integer
+              format: int32
+            request:
+              $ref: "#/components/schemas/VarBinds"
+            response:
+              $ref: "#/components/schemas/VarBinds"
+        record:
+          description: >
+            Human friendly representation of the simulation data item
+            being used for answering this query.
+          type: object
+          properties:
+            name:
+              type: string
+        raw:
+          description: >
+            Raw SNMP packets as in the wire.
+          type: object
+          properties:
+            inbound:
+              type: string
+            outbound:
+              type: string
+        status:
+          $ref: "#/components/schemas/MessageStatus"
+        tags:
+          description: >
+            Free form tags set by the Simulator to assist grouping/searching.
+            Tags can include IDs of the agent that handled this message and
+            ID of the recording collection used to form the response.
+          type: array
+          items:
+            type: string
+
+    MessageStatus:
+      description: >
+        SNMP request outcome
+      type: object
+      properties:
+        result:
+          type: string
+          enum: [OK, FAILED]
+        category:
+          description: >
+            On failure, where exactly it failed
+          type: string
+          enum: [user, community, signature, cipher, parser, access, object,
+                 routing, variation, other]
+        details:
+          description: >
+            On failure, unstructured message explaining the cause
+          type: string
+
+    VarBind:
+      description: >
+        A single SNMP PDU variable-binding.
+      type: object
+      required:
+        - oid
+        - type
+        - value
+      properties:
+        oid:
+          description: >
+            OID associated with this SNMP managed object instance
+          type: string
+          pattern: ".*"  # TODO OID regexp
+        type:
+          description: >
+            SNMP type of the value associated with this managed object instance.
+          type: string
+          enum: [integer32, octetstring, counter32, counter64, gauge32,
+                 opaque, ipaddress, null, timeticks]
+        value:
+          description: >
+            Static value returned by this managed object instance
+          type: string
+
+    VarBinds:
+      description: >
+        An ordered collection of SNMP PDU variable-binding pairs
+      type: object
+      properties:
+        elements:
+          type: array
+          items:
+            $ref: "#/components/schemas/VarBind"
+
+    Messages:
+      description: >
+        An array of messages.
+      type: array
+      items:
+        $ref: "#/components/schemas/Message"
+
+    Process:
+      description: >
+        SNMP simulator system is composed of many running processes.
+        This object describes common properties of a process.
+      type: object
+      properties:
+        cmdline:
+          description: >
+            Path to process executable and its command-line parameters.
+          type: string
+        uptime:
+          description: >
+            How long this process has been up (in seconds).
+          type: integer
+        owner:
+          description: >
+            OS user:group owning this process.
+          type: string
+        memory:
+          description: >
+            How much virtual memory this process is consuming.
+          type: integer
+        cpu:
+          description: >
+            How much CPU this process is putting on CPU (last 1, 5, and
+            15 minutes).
+          type: integer
+        files:
+          description: >
+            How many open files this process has.
+          type: integer
+        health:
+          description: >
+            How healthy this process has been lately in terms of the number
+            of internal events occurred since process start. Warning-level
+            expire automatically over time.
+          type: object
+          properties:
+            fatal:
+              type: integer
+            critical:
+              type: integer
+            warning:
+              type: integer
+            info:
+              type: integer
+
+    Processes:
+      description: >
+        An array of process information.
+      type: array
+      items:
+        $ref: "#/components/schemas/Process"
+
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string


### PR DESCRIPTION
Proposes OpenAPI 3.0 compliant spec designed to make snmpsimd
fully controllable via REST API. Docs & mocks can be found on [Swagger](https://app.swaggerhub.com/apis/etingof/snmpsimd-control-plane/1.0.0#/endpoints/listEndpoints).