### PR TITLE
Replace `getopt` with `argparse` in all CLI tools

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,15 @@ Revision 1.0.0, released XX-12-2019
 - Converted integration tests from depending on @snmplabs.com to local,
   autonomous test suite.
 
+- Replace `getopt` with `argparse` in all CLI tools The latter is way more
+  advanced and Pythonic.
+
+  Due to differences in `getopt` vs `argparse` usage model, slight changes
+  in tools' behavior is not impossible.
+
+  Some legacy, backward compatibility CLI options have been dropped by
+  way of this change.
+
 Revision 0.4.8, released XX-08-2019
 -----------------------------------
 

--- a/snmpsim/commands/mib2rec.py
+++ b/snmpsim/commands/mib2rec.py
@@ -6,7 +6,8 @@
 #
 # SNMP Simulator MIB to data file converter
 #
-import getopt
+import argparse
+import functools
 import os
 import random
 import sys
@@ -22,6 +23,7 @@ from pysnmp.smi import error
 from pysnmp.smi import view
 from pysnmp.smi.rfc1902 import ObjectIdentity
 
+from snmpsim import utils
 from snmpsim.error import SnmpsimError
 from snmpsim.record import dump
 from snmpsim.record import mvc
@@ -38,274 +40,170 @@ RECORD_TYPES = {
     snmprec.CompressedSnmprecRecord.ext: snmprec.CompressedSnmprecRecord()
 }
 
-HELP_MESSAGE = """\
-Usage: %s [--help]
-    [--version]
-    [--debug=<%s>]
-    [--quiet]
-    [--mib-source=<url>]
-    [--pysnmp-mib-dir=</path/to/pysnmp/mibs]
-    [--mib-module=<MIB-NAME>]
-    [--start-object=<MIB-NAME::[symbol-name]|OID>]
-    [--stop-object=<MIB-NAME::[symbol-name]|OID>]
-    [--manual-values]
-    [--automatic-values=<max-probes>]
-    [--table-size=<number>]
-    [--destination-record-type=<%s>]
-    [--output-file=<filename>]
-    [--string-pool=<words>]
-    [--string-pool-file=</path/to/text/file>]
-    [--counter-range=<min,max>]
-    [--counter64-range=<min,max>]
-    [--gauge-range=<min,max>]
-    [--timeticks-range=<min,max>]
-    [--unsigned-range=<min,max>]
-    [--integer32-range=<min,max>]\
-""" % (sys.argv[0],
-       '|'.join([x for x in getattr(debug, 'FLAG_MAP', getattr(debug, 'flagMap', ()))
-                 if x not in ('app', 'msgproc', 'proxy', 'io', 'secmod',
-                              'dsp', 'acl')]),
-       '|'.join(RECORD_TYPES))
+DESCRIPTION = (
+    'Converts MIB modules into SNMP simulation data files. '
+    'Chooses random values or asks interactively. '
+    'Fills SNMP conceptual tables with consistent indices.')
 
-PROGRAM_NAME = os.path.basename(sys.argv[0])
+
+def _parse_mib_object(arg, last=False):
+    if '::' in arg:
+        return ObjectIdentity(*arg.split('::', 1), last=last)
+
+    else:
+        return univ.ObjectIdentifier(arg)
+
+
+def _parse_range(arg):
+    try:
+        minimum, maximum = [int(x) for x in arg.split(',')]
+
+    except Exception as exc:
+        raise SnmpsimError('Malformed integer range %s: %s' % (arg, exc))
+
+    return minimum, maximum
 
 
 def main():
-    # Defaults
-    verboseFlag = True
-    startOID = stopOID = None
-    mibSources = []
-    defaultMibSources = ['http://mibs.snmplabs.com/asn1/@mib@']
-    dstRecordType = 'snmprec'
-    outputFile = None
-    stringPool = 'Jaded zombies acted quaintly but kept driving their oxen forward'.split()
-    counterRange = 0, 0xffffffff
-    counter64Range = 0, 0xffffffffffffffff
-    gaugeRange = 0, 0xffffffff
-    timeticksRange = 0, 0xffffffff
-    unsignedRange = 0, 65535
-    int32Range = 0, 32  # these values are more likely to fit constraints
-    automaticValues = 5000
-    tableSize = 10
-    modNames = []
-    mibDirs = []
 
-    try:
-        opts, params = getopt.getopt(
-            sys.argv[1:], 'hv',
-            ['help', 'version', 'debug=', 'quiet',
-             'pysnmp-mib-dir=', 'mib-module=', 'start-oid=', 'stop-oid=',
-             'mib-source=', 'start-object=', 'stop-object=',
-             'manual-values', 'automatic-values=', 'table-size=',
-             'destination-record-type=',
-             'output-file=', 'string-pool=', 'string-pool-file=',
-             'integer32-range=', 'counter-range=', 'counter64-range=',
-             'gauge-range=', 'unsigned-range=', 'timeticks-range='])
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
 
-    except Exception as exc:
-        sys.stderr.write('ERROR: %s\r\n%s\r\n' % (exc, HELP_MESSAGE))
-        return 1
+    parser.add_argument(
+        '-v', '--version', action='version',
+        version=utils.TITLE)
 
-    if params:
-        sys.stderr.write('ERROR: extra arguments supplied %s\r\n'
-                         '%s\r\n' % (params, HELP_MESSAGE))
-        return 1
+    parser.add_argument(
+        '--quiet', action='store_true',
+        help='Do not print out informational messages')
 
-    for opt in opts:
+    parser.add_argument(
+        '--debug', choices=debug.flagMap,
+        action='append', type=str, default=[],
+        help='Enable one or more categories of SNMP debugging.')
 
-        if opt[0] == '-h' or opt[0] == '--help':
-            sys.stderr.write("""\
-Synopsis:
-  Converts MIB modules into SNMP Simulator data files.
-  Chooses random values or can ask for them interactively.
-  Able to fill SNMP conceptual tables with consistent indices.
+    parser.add_argument(
+        '--mib-source', dest='mib_sources', metavar='<URI|PATH>',
+        action='append', type=str,
+        default=['http://mibs.snmplabs.com/asn1/@mib@'],
+        help='One or more URIs pointing to a collection of ASN.1 MIB files.'
+             'Optional "@mib@" token gets replaced with desired MIB module '
+             'name during MIB search.')
 
-Documentation:
-  http://snmplabs.com/snmpsim/simulation-based-on-mibs.html
-%s
-""" % HELP_MESSAGE)
-            return 1
+    parser.add_argument(
+        '--mib-module', dest='mib_modules', action='append',
+        type=str, required=True,
+        help='MIB module to generate simulation data from')
 
-        if opt[0] == '-v' or opt[0] == '--version':
-            import snmpsim
-            import pysmi
-            import pysnmp
-            import pyasn1
+    parser.add_argument(
+        '--start-object', metavar='<MIB::Object|OID>', type=_parse_mib_object,
+        help='Drop all simulation data records prior to this OID specified '
+             'as MIB object (MIB::Object) or OID (1.3.6.)')
 
-            sys.stderr.write("""\
-SNMP Simulator version %s, written by Ilya Etingof <etingof@gmail.com>
-Using foundation libraries: pysmi %s, pysnmp %s, pyasn1 %s.
-Python interpreter: %s
-Software documentation and support at http://snmplabs.com/snmpsim
-%s
-""" % (snmpsim.__version__,
-           getattr(pysmi, '__version__', 'unknown'),
-           getattr(pysnmp, '__version__', 'unknown'),
-           getattr(pyasn1, '__version__', 'unknown'),
-           sys.version, HELP_MESSAGE))
-            return 1
+    parser.add_argument(
+        '--stop-object', metavar='<MIB::Object|OID>',
+        type=functools.partial(_parse_mib_object, last=True),
+        help='Drop all simulation data records after this OID specified '
+             'as MIB object (MIB::Object) or OID (1.3.6.)')
 
-        if opt[0] == '--debug':
-            debug.setLogger(debug.Debug(*opt[1].split(',')))
+    parser.add_argument(
+        '--manual-values', action='store_true',
+        help='Fill all managed objects values interactively')
 
-        if opt[0] == '--quiet':
-            verboseFlag = False
+    parser.add_argument(
+        '--automatic-values', type=int, default=5000,
+        help='Probe for suitable managed object value this many times '
+             'prior to failing over to manual value specification')
 
-        if opt[0] == '--pysnmp-mib-dir':
-            mibDirs.append(opt[1])
+    parser.add_argument(
+        '--table-size', type=int, default=10,
+        help='Generate SNMP conceptual tables with this many rows')
 
-        if opt[0] == '--mib-module':
-            modNames.append(opt[1])
+    parser.add_argument(
+        '--destination-record-type', choices=RECORD_TYPES, default='snmprec',
+        help='Produce simulation data with record of this type')
 
-        # obsolete begin
-        if opt[0] == '--start-oid':
-            startOID = univ.ObjectIdentifier(opt[1])
+    parser.add_argument(
+        '--output-file', metavar='<FILE>', type=str,
+        help='SNMP simulation data file to write records to')
 
-        if opt[0] == '--stop-oid':
-            stopOID = univ.ObjectIdentifier(opt[1])
-        # obsolete end
+    parser.add_argument(
+        '--string-pool', metavar='<words>', action='append',
+        help='Words to use for simulated string values')
 
-        if opt[0] == '--mib-source':
-            mibSources.append(opt[1])
+    parser.add_argument(
+        '--string-pool-file', metavar='<FILE>', type=str,
+        help='File containing the words for simulating SNMP string values')
 
-        if opt[0] == '--start-object':
-            startOID = ObjectIdentity(
-                *opt[1].split('::', 1))
+    parser.add_argument(
+        '--integer32-range', metavar='<min,max>',
+        type=_parse_range, default=(0, 32),
+        help='Range of values used to populate simulated Integer32 values')
 
-        if opt[0] == '--stop-object':
-            stopOID = ObjectIdentity(
-                *opt[1].split('::', 1), **dict(last=True))
+    parser.add_argument(
+        '--unsigned-range', metavar='<min,max>',
+        type=_parse_range, default=(0, 65535),
+        help='Range of values used to populate simulated Unsigned values')
 
-        if opt[0] == '--manual-values':
-            automaticValues = 0
+    parser.add_argument(
+        '--counter-range', metavar='<min,max>',
+        type=_parse_range, default=(0, 0xffffffff),
+        help='Range of values used to populate simulated Counter values')
 
-        if opt[0] == '--automatic-values':
-            try:
-                automaticValues = int(opt[1])
+    parser.add_argument(
+        '--counter64-range', metavar='<min,max>',
+        type=_parse_range, default=(0, 0xffffffffffffffff),
+        help='Range of values used to populate simulated Counter64 values')
 
-            except ValueError as exc:
-                sys.stderr.write(
-                    'ERROR: bad value %s: %s\r\n' % (opt[1], exc))
-                return 1
+    parser.add_argument(
+        '--gauge-range', metavar='<min,max>',
+        type=_parse_range, default=(0, 0xffffffff),
+        help='Range of values used to populate simulated Gauge values')
 
-        if opt[0] == '--table-size':
-            try:
-                tableSize = int(opt[1])
+    parser.add_argument(
+        '--timeticks-range', metavar='<min,max>',
+        type=_parse_range, default=(0, 0xffffffff),
+        help='Range of values used to populate simulated Timeticks values')
 
-            except ValueError as exc:
-                sys.stderr.write('ERROR: bad value %s: %s\r\n' % (opt[1], exc))
-                return 1
+    args = parser.parse_args()
 
-        if opt[0] == '--destination-record-type':
-            if opt[1] not in RECORD_TYPES:
-                sys.stderr.write(
-                    'ERROR: unknown record type <%s> (known types are %s)\r\n%s'
-                    '\r\n' % (opt[1], ', '.join(RECORD_TYPES),
-                              HELP_MESSAGE))
-                return 1
+    if args.debug:
+        debug.setLogger(debug.Debug(*args.debug))
 
-            dstRecordType = opt[1]
+    if args.manual_values:
+        args.automatic_values = 0
 
-        if opt[0] == '--output-file':
-            outputFile = open(opt[1], 'wb')
+    if args.string_pool_file:
+        with open(args.string_pool_file) as fl:
+            args.string_pool = fl.read().split()
 
-        if opt[0] == '--string-pool':
-            stringPool = opt[1].split()
+    elif args.string_pool:
+        args.string_pool = ['Jaded', 'zombies', 'acted', 'quaintly', 'but',
+                            'kept', 'driving', 'their', 'oxen', 'forward']
 
-        if opt[0] == '--string-pool-file':
-            try:
-                f = open(opt[1])
-                stringPool = f.read().split()
-                f.close()
+    if args.output_file:
+        ext = os.path.extsep + RECORD_TYPES[args.destination_record_type].ext
 
-            except Exception as exc:
-                sys.stderr.write(
-                    'ERROR: text file "%s" open failure '
-                    '%s\r\n' % (opt[1], exc))
-                return 1
+        if not args.output_file.endswith(ext):
+            args.output_file += ext
 
-        if opt[0] == '--counter-range':
-            try:
-                counterRange = [int(x) for x in opt[1].split(',')]
-
-            except ValueError as exc:
-                sys.stderr.write(
-                    'ERROR: bad value %s: %s\r\n' % (opt[1], exc))
-                return 1
-
-        if opt[0] == '--counter64-range':
-            try:
-                counter64Range = [int(x) for x in opt[1].split(',')]
-
-            except ValueError as exc:
-                sys.stderr.write(
-                    'ERROR: bad value %s: %s\r\n' % (opt[1], exc))
-                return 1
-
-        if opt[0] == '--gauge-range':
-            try:
-                gaugeRange = [int(x) for x in opt[1].split(',')]
-
-            except ValueError as exc:
-                sys.stderr.write(
-                    'ERROR: bad value %s: %s\r\n' % (opt[1], exc))
-                return 1
-
-        if opt[0] == '--timeticks-range':
-            try:
-                timeticksRange = [int(x) for x in opt[1].split(',')]
-
-            except ValueError as exc:
-                sys.stderr.write(
-                    'ERROR: bad value %s: %s\r\n' % (opt[1], exc))
-                return 1
-
-        if opt[0] == '--integer32-range':
-            try:
-                int32Range = [int(x) for x in opt[1].split(',')]
-
-            except ValueError as exc:
-                sys.stderr.write(
-                    'ERROR: bad value %s: %s\r\n' % (opt[1], exc))
-                return 1
-
-        if opt[0] == '--unsigned-range':
-            try:
-                unsignedRange = [int(x) for x in opt[1].split(',')]
-
-            except ValueError as exc:
-                sys.stderr.write('ERROR: bad value %s: %s\r\n' % (opt[1], exc))
-                return 1
-
-    if outputFile:
-        ext = os.path.extsep + RECORD_TYPES[dstRecordType].ext
-
-        if not outputFile.endswith(ext):
-            outputFile += ext
-
-        outputFile = RECORD_TYPES[dstRecordType].open(outputFile, 'wb')
+        args.output_file = RECORD_TYPES[args.destination_record_type].open(
+            args.output_file, 'wb')
 
     else:
-        outputFile = sys.stdout
+        args.output_file = sys.stdout
 
         if sys.version_info >= (3, 0, 0):
             # binary mode write
-            outputFile = sys.stdout.buffer
+            args.output_file = sys.stdout.buffer
 
         elif sys.platform == "win32":
             import msvcrt
 
             msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
 
-    # Catch missing params
-    if not modNames:
-        sys.stderr.write(
-            'ERROR: MIB modules not specified\r\n%s\r\n' % HELP_MESSAGE)
-        return 1
+    def getValue(syntax, hint='', automatic_values=args.automatic_values):
 
-    def getValue(syntax, hint='', automaticValues=automaticValues):
-
-        makeGuess = automaticValues
+        makeGuess = args.automatic_values
 
         val = None
 
@@ -315,26 +213,26 @@ Software documentation and support at http://snmplabs.com/snmpsim
                     val = '.'.join([str(random.randrange(1, 256)) for x in range(4)])
 
                 elif isinstance(syntax, rfc1902.TimeTicks):
-                    val = random.randrange(timeticksRange[0], timeticksRange[1])
+                    val = random.randrange(args.timeticks_range[0], args.timeticks_range[1])
 
                 elif isinstance(syntax, rfc1902.Gauge32):
-                    val = random.randrange(gaugeRange[0], gaugeRange[1])
+                    val = random.randrange(args.gauge_range[0], args.gauge_range[1])
 
                 elif isinstance(syntax, rfc1902.Counter32):
-                    val = random.randrange(counterRange[0], counterRange[1])
+                    val = random.randrange(args.counter_range[0], args.counter_range[1])
 
                 elif isinstance(syntax, rfc1902.Integer32):
-                    val = random.randrange(int32Range[0], int32Range[1])
+                    val = random.randrange(args.integer32_range[0], args.integer32_range[1])
 
                 elif isinstance(syntax, rfc1902.Unsigned32):
-                    val = random.randrange(unsignedRange[0], unsignedRange[1])
+                    val = random.randrange(args.unsigned_range[0], args.unsigned_range[1])
 
                 elif isinstance(syntax, rfc1902.Counter64):
-                    val = random.randrange(counter64Range[0], counter64Range[1])
+                    val = random.randrange(args.counter64_range[0], args.counter64_range[1])
 
                 elif isinstance(syntax, univ.OctetString):
                     maxWords = 10
-                    val = ' '.join([stringPool[random.randrange(0, len(stringPool))]
+                    val = ' '.join([args.string_pool[random.randrange(0, len(args.string_pool))]
                                     for i in range(random.randrange(1, maxWords))])
 
                 elif isinstance(syntax, univ.ObjectIdentifier):
@@ -397,12 +295,6 @@ Software documentation and support at http://snmplabs.com/snmpsim
 
     mibBuilder = builder.MibBuilder()
 
-    mibBuilder.setMibSources(
-        *mibBuilder.getMibSources() + tuple(
-            [builder.ZipMibSource(m).init() for m in mibDirs]
-        )
-    )
-
     # Load MIB tree foundation classes
     (MibScalar,
      MibTable,
@@ -417,16 +309,14 @@ Software documentation and support at http://snmplabs.com/snmpsim
 
     mibViewController = view.MibViewController(mibBuilder)
 
-    compiler.addMibCompiler(
-        mibBuilder, sources=mibSources or defaultMibSources
-    )
+    compiler.addMibCompiler(mibBuilder, sources=args.mib_sources)
 
     try:
-        if isinstance(startOID, ObjectIdentity):
-            startOID.resolveWithMib(mibViewController)
+        if isinstance(args.start_object, ObjectIdentity):
+            args.start_object.resolveWithMib(mibViewController)
 
-        if isinstance(stopOID, ObjectIdentity):
-            stopOID.resolveWithMib(mibViewController)
+        if isinstance(args.stop_object, ObjectIdentity):
+            args.stop_object.resolveWithMib(mibViewController)
 
     except error.PySnmpError as exc:
         sys.stderr.write('ERROR: %s\r\n' % exc)
@@ -435,12 +325,12 @@ Software documentation and support at http://snmplabs.com/snmpsim
     output = []
 
     # MIBs walk
-    for modName in modNames:
-        if verboseFlag:
+    for modName in args.mib_modules:
+        if not args.quiet:
             sys.stderr.write(
                 '# MIB module: %s, from %s till '
-                '%s\r\n' % (modName, startOID or 'the beginning',
-                            stopOID or 'the end'))
+                '%s\r\n' % (modName, args.start_object or 'the beginning',
+                            args.stop_object or 'the end'))
 
         try:
             oid = ObjectIdentity(modName).resolveWithMib(mibViewController)
@@ -465,16 +355,16 @@ Software documentation and support at http://snmplabs.com/snmpsim
             if rowOID and not rowOID.isPrefixOf(oid):
                 thisTableSize += 1
 
-                if automaticValues:
-                    if thisTableSize < tableSize:
+                if args.automatic_values:
+                    if thisTableSize < args.table_size:
                         oid = tuple(rowOID)
-                        if verboseFlag:
+                        if not args.quiet:
                             sys.stderr.write(
                                 '# Synthesizing row #%d of table %s\r\n' % (
                                     thisTableSize, rowOID))
 
                     else:
-                        if verboseFlag:
+                        if not args.quiet:
                             sys.stderr.write(
                                 '# Finished table %s (%d rows)\r\n' % (
                                     rowOID, thisTableSize))
@@ -495,17 +385,17 @@ Software documentation and support at http://snmplabs.com/snmpsim
                                 break
 
                             elif line[0] in ('n', 'N'):
-                                if verboseFlag:
+                                if not args.quiet:
                                     sys.stderr.write(
                                         '# Finished table %s (%d rows)\r\n' % (
                                             rowOID, thisTableSize))
                                 rowOID = None
                                 break
 
-            if startOID and oid < startOID:
+            if args.start_object and oid < args.start_object:
                 continue  # skip on premature OID
 
-            if stopOID and oid > stopOID:
+            if args.stop_object and oid > args.stop_object:
                 break  # stop on out of range condition
 
             mibName, symName, _ = mibViewController.getNodeLocation(oid)
@@ -513,7 +403,7 @@ Software documentation and support at http://snmplabs.com/snmpsim
 
             if isinstance(node, MibTable):
                 hint = '# Table %s::%s\r\n' % (mibName, symName)
-                if verboseFlag:
+                if not args.quiet:
                     sys.stderr.write(
                         '# Starting table %s::%s (%s)\r\n' % (
                             mibName, symName, univ.ObjectIdentifier(oid)))
@@ -531,13 +421,13 @@ Software documentation and support at http://snmplabs.com/snmpsim
                         idxModName, idxSymName, idxNode.syntax.__class__.__name__)
 
                     rowIndices[idxNode.name] = getValue(
-                        idxNode.syntax, verboseFlag and rowHint or '')
+                        idxNode.syntax, not args.quiet and rowHint or '')
 
                     suffix = suffix + node.getAsName(
                         rowIndices[idxNode.name], impliedFlag)
 
                 if not rowIndices:
-                    if verboseFlag:
+                    if not args.quiet:
                         sys.stderr.write(
                             '# WARNING: %s::%s table has no index!\r\n' % (
                                 mibName, symName))
@@ -555,7 +445,7 @@ Software documentation and support at http://snmplabs.com/snmpsim
 
                 else:
                     val = getValue(
-                        node.syntax, verboseFlag and (
+                        node.syntax, not args.quiet and (
                                 rowHint + '# Column %s::%s (type'
                                           ' %s)\r\n' % (mibName, symName,
                                                         node.syntax.__class__.__name__) or ''))
@@ -565,7 +455,7 @@ Software documentation and support at http://snmplabs.com/snmpsim
                 oid = node.name
                 suffix = (0,)
                 val = getValue(
-                    node.syntax, verboseFlag and '# Scalar %s::%s (type %s)\r\n' % (
+                    node.syntax, not args.quiet and '# Scalar %s::%s (type %s)\r\n' % (
                         mibName, symName, node.syntax.__class__.__name__) or '')
 
             else:
@@ -580,13 +470,13 @@ Software documentation and support at http://snmplabs.com/snmpsim
 
         for oid, val in output:
             if oid in unique:
-                if verboseFlag:
+                if not args.quiet:
                     sys.stderr.write(
                         '# Dropping duplicate OID %s\r\n' % (
                             univ.ObjectIdentifier(oid),))
             else:
                 try:
-                    outputFile.write(dataFileHandler.format(oid, val))
+                    args.output_file.write(dataFileHandler.format(oid, val))
 
                 except SnmpsimError as exc:
                     sys.stderr.write('ERROR: %s\r\n' % (exc,))
@@ -594,12 +484,12 @@ Software documentation and support at http://snmplabs.com/snmpsim
                 else:
                     unique.add(oid)
 
-        if verboseFlag:
+        if not args.quiet:
             sys.stderr.write(
                 '# End of %s, %s OID(s) dumped\r\n' % (modName, len(unique)))
 
-    outputFile.flush()
-    outputFile.close()
+    args.output_file.flush()
+    args.output_file.close()
 
     return 0
 

--- a/snmpsim/utils.py
+++ b/snmpsim/utils.py
@@ -1,0 +1,30 @@
+#
+# This file is part of snmpsim software.
+#
+# Copyright (c) 2010-2019, Ilya Etingof <etingof@gmail.com>
+# License: http://snmplabs.com/snmpsim/license.html
+#
+import importlib
+import sys
+
+import pysnmp
+import pysmi
+import pyasn1
+import snmpsim
+
+TITLE = """\
+SNMP Simulator version %s, written by Ilya Etingof <etingof@gmail.com>
+Using foundation libraries: pysmi %s, pysnmp %s, pyasn1 %s.
+Python interpreter: %s
+Documentation and support at http://snmplabs.com/snmpsim
+""" % (snmpsim.__version__, pysmi.__version__, pysnmp.__version__,
+       pyasn1.__version__, sys.version)
+
+
+def try_load(module, package=None):
+    """Try to load given module, return `None` on failure"""
+    try:
+        return importlib.import_module(module, package)
+
+    except ImportError:
+        return


### PR DESCRIPTION
Replace `getopt` with `argparse` in all CLI tools The latter is way more advanced and Pythonic.

Due to differences in `getopt` vs `argparse` usage model, slight changes in tools' behavior is not impossible.

Some legacy, backward compatibility CLI options have been dropped by way of this change.