### PR TITLE
Simplify Recording model in REST API spec

### DIFF
--- a/docs/snmpsim-mgmt-api.yaml
+++ b/docs/snmpsim-mgmt-api.yaml
@@ -667,14 +667,14 @@ components:
         SNMPv3 USM user entry. Contains SNMPv3 credentials grouped by
         user name.
       required:
-        - id
         - username
       properties:
-        id:
+        user:
           description: >
-            User entry ID
-          type: integer
-          format: int64
+            USM user name.
+          type: string
+          minLength: 1
+          maxLength: 32
         name:
           description: >
             SNMP security name of this entry.
@@ -684,12 +684,6 @@ components:
             SNMP security level.
           type: string
           enum: ["noAuthNoPriv", "authNoPriv", "authPriv"]
-        user:
-          description: >
-            USM user name.
-          type: string
-          minLength: 1
-          maxLength: 32
         authKey:
           description: >
             USM user authentication key
@@ -721,11 +715,6 @@ components:
         - id
         - name
       properties:
-        id:
-          description: >
-            Community name ID
-          type: integer
-          format: int64
         name:
           description: >
             SNMP security name of this entry.
@@ -780,9 +769,9 @@ components:
           description: >
             Descriptive name of this transport endpoint e.g. "port123 at vif456"
           type: string
-        agentId:
+        engineId:
           description: >
-            SNMP agent ID binding this endpoint
+            SNMP engine ID binding this endpoint
           type: integer
           format: int64
         domain:
@@ -798,82 +787,6 @@ components:
       type: array
       items:
         $ref: "#/components/schemas/Endpoint"
-
-    Record:
-      description: >
-        SNMP record representing a single line of `.snmprec` file. In SNMP
-        parlance it's also known as SNMP managed object instance.
-
-        On SNMP side of things, managed object instance is identified
-        by a unique OID and, sometimes, an associated value representing the
-        state of the backend application object being managed via SNMP.
-
-        Depending on the nature of the managed object, associated value can
-        be settable and/or modifiable.
-      type: object
-      required:
-        - id
-        - oid
-        - type
-      properties:
-        id:
-          type: integer
-          format: int64
-        oid:
-          description: >
-            OID associated with this SNMP managed object instance
-          type: string
-          pattern: ".*"  # TODO OID regexp
-        type:
-          description: >
-            SNMP type of the value associated with this managed object instance.
-          type: string
-          enum: ["integer32", "octetstring", "counter32", "counter64", "gauge32",
-                 "opaque", "ipaddress", "null", "timeticks"]
-        value:
-          description: >
-            Static value returned by this managed object instance
-          type: string
-        variation:
-          description: >
-            Variation module invoked when serving this managed object instance
-          type: string
-          enum: ["numeric", "error", "delay", "notification", "multiplex", "redis",
-                 "sql", "subprocess", "writecache"]
-        variationOptions:
-          type: string
-
-    Recording:
-      description: >
-        Ordered collection of SNMP records representing a single `.snmprec`
-        file.
-      type: object
-      properties:
-        name:
-          description: >
-            Descriptive name of this recording e.g. "cisco5300 routing and L2 tables"
-          type: string
-        path:
-          description: >
-            Path to the `.snmprec` file on the filesystem under a simulation data
-            directory where this recording resides.
-        records:
-          type: array
-          items:
-            $ref: "#/components/schemas/Record"
-
-    Recordings:
-      description: >
-        A collection of SNMP recordings
-      type: object
-      properties:
-        id:
-          type: integer
-          format: int64
-        recordings:
-          type: array
-          items:
-            $ref: "#/components/schemas/Recording"
 
     Agent:
       description: >
@@ -928,6 +841,40 @@ components:
       type: array
       items:
         $ref: "#/components/schemas/Agent"
+
+    Recording:
+      description: >
+        Represents a single simulation data file residing by `path` under
+        simulation data root.
+      type: object
+      required:
+        - id
+        - path
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          description: >
+            Descriptive name of this recording e.g. "cisco5300 routing and L2 tables"
+          type: string
+        path:
+          description: >
+            Path to the `.snmprec` file on the filesystem under a simulation data
+            directory where this recording resides.
+
+    Recordings:
+      description: >
+        A collection of SNMP recordings
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        recordings:
+          type: array
+          items:
+            $ref: "#/components/schemas/Recording"
 
     Lab:
       description: >


### PR DESCRIPTION
Exposing .snmprec files in management API at the record detail
seems too expensive for the time being. Let's operate just on
metadata i.e. .snmprec paths and the entire contents.