### PR TITLE
Fixed parse NULL values from snmpwalk

### DIFF
--- a/snmpsim/grammar/walk.py
+++ b/snmpsim/grammar/walk.py
@@ -20,6 +20,7 @@ class WalkGrammar(abstract.AbstractGrammar):
     # case-insensitive keys as snmpwalk output tend to vary
     TAG_MAP = {
         'OID:': rfc1902.ObjectName,
+        'NULL:': univ.Null,
         'INTEGER:': rfc1902.Integer,
         'STRING:': rfc1902.OctetString,
         'BITS:': rfc1902.Bits,
@@ -165,6 +166,10 @@ class WalkGrammar(abstract.AbstractGrammar):
         # this is implicit snmpwalk's fuzziness
         elif value == '""' or value == 'STRING:':
             tag = 'STRING:'
+            value = ''
+
+        elif value == 'NULL':
+            tag = 'NULL:'
             value = ''
 
         else:


### PR DESCRIPTION
Snmpwalk values with NULL variable type incorrectly parsed:
`.1.3.6.1.4.1.3478.6.2.1.4.1.6.32 = NULL`
get error:
`# Skipping broken record <b'.1.3.6.1.4.1.3478.6.2.1.4.1.6.32 = NULL\n'>: value evaluation error for tag 'TIMETICKS:', value 'NULL'`