### PR TITLE
Added snmpwalk convert support for Opaque extra types UInt64 and Int64

### DIFF
--- a/snmpsim/grammar/walk.py
+++ b/snmpsim/grammar/walk.py
@@ -86,13 +86,13 @@ class WalkGrammar(abstract.AbstractGrammar):
             # .1.3.6.1.4.1.2021.10.1.6.2 = Opaque: UInt64: 18446744073709551614
             # there should be BER encoder, but really I not how do this,
             # I just convert to HEX value instead
-            hex = format(int(value), '#0x').replace('0x', '').upper()
+            hex = '{:X}'.format(int(value))
             add = len(hex) % 2
             hex = add * '0' + hex
             parts = [hex[i:i + 2] for i in range(0, len(hex), 2)]
 
             # value len
-            hex = format(len(parts), '#0x').replace('0x', '').upper()
+            hex = '{:X}'.format(len(parts))
             add = len(hex) % 2
             hex = add * '0' + hex
             parts = [hex[i:i + 2] for i in range(0, len(hex), 2)] + parts
@@ -103,14 +103,13 @@ class WalkGrammar(abstract.AbstractGrammar):
         elif opaque_tag.startswith('INT64: '):
             # .1.3.6.1.4.1.2021.10.1.6.3 = Opaque: Int64: 9223372036854775806
             # .1.3.6.1.4.1.2021.10.1.6.4 = Opaque: Int64: -2
-            # really not know how operate with signed integers (currently support only positive numbers)
-            hex = format(int(value), '#0x').replace('0x', '').upper()
+            hex = '{:X}'.format(int(value) & (2**64-1))
             add = len(hex) % 2
             hex = add * '0' + hex
             parts = [hex[i:i + 2] for i in range(0, len(hex), 2)]
 
             # value len
-            hex = format(len(parts), '#0x').replace('0x', '').upper()
+            hex = '{:X}'.format(len(parts))
             add = len(hex) % 2
             hex = add * '0' + hex
             parts = [hex[i:i + 2] for i in range(0, len(hex), 2)] + parts

--- a/snmpsim/grammar/walk.py
+++ b/snmpsim/grammar/walk.py
@@ -73,6 +73,7 @@ class WalkGrammar(abstract.AbstractGrammar):
 
     @staticmethod
     def _opaque_filter(value):
+        opaque_tag = ''
         match = re.match(r'^(\w+: +)', value)
         if match:
             opaque_tag = match.group(1).upper()


### PR DESCRIPTION
Added convertion support for additional Opaque types with integers (only which I have in snmpwalks).
Ie:
```
.1.3.6.1.4.1.2021.10.1.6.1 = Opaque: Float: 0.340820
.1.3.6.1.4.1.2021.10.1.6.2 = Opaque: UInt64: 18446744073709551614
.1.3.6.1.4.1.2021.10.1.6.3 = Opaque: Int64: 9223372036854775806
.1.3.6.1.4.1.2021.10.1.6.4 = Opaque: Int64: -2
```

Notes:
 - int to snmp hex convertion probably should be in pyasn1 library or pyasn1.codec.ber should know how convert int to ber serialization
 - really need universally way with BER serialization for any possible subtypes (also possible double)
 - information how detect Opaque subtype tags I founded there https://github.com/delimitry/snmp-server/blob/master/snmp-server.py

Currently I just added hard fix for self snmpwalks received from user.