### PR TITLE
* added inform callback missing parameter

### DIFF
--- a/variation/notification.py
+++ b/variation/notification.py
@@ -47,7 +47,7 @@ MODULE_OPTIONS = (
 )
 
 
-def _cbFun(sendRequestHandle, errorIndication, errorStatus,
+def _cbFun(snmpEngine, sendRequestHandle, errorIndication, errorStatus,
            errorIndex, varBinds, cbCtx):
     oid, value = cbCtx
 


### PR DESCRIPTION
pysnmp expects inform callback to have snmpEngine as first parameter.