### PR TITLE
bugfix: Unable to record from MIB 

### DIFF
--- a/snmpsim/commands/mib2rec.py
+++ b/snmpsim/commands/mib2rec.py
@@ -176,7 +176,7 @@ def main():
         with open(args.string_pool_file) as fl:
             args.string_pool = fl.read().split()
 
-    elif args.string_pool:
+    elif not args.string_pool:
         args.string_pool = ['Jaded', 'zombies', 'acted', 'quaintly', 'but',
                             'kept', 'driving', 'their', 'oxen', 'forward']
 


### PR DESCRIPTION
bugfix: Unable to record from MIB 


https://github.com/etingof/snmpsim/issues/163

My point of view, this is a judgment written in reverse.